### PR TITLE
Temporary Overwrite of Broken Stages

### DIFF
--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -596,12 +596,19 @@ class Settings(ObjectDict):
 
   def __enter__(self):
     import copy
-    object.__setattr__(self, "_backup", copy.deepcopy(self))
+    try:
+      # check if _backup exists
+      backup = object.__getattribute__(self, "_backup")
+      # if it does, append a copy of self
+      backup.append(copy.deepcopy(self))
+    except AttributeError:
+      # if it doesn't exist yet, make a list
+      object.__setattr__(self, "_backup", [copy.deepcopy(self)])
 
   def __exit__(self, type_, value, traceback):
     self.clear()
-    self.update(self._backup)
-    del self._backup
+    backup = self._backup.pop()
+    self.update(backup)
 
 
 settings = LazySettings()


### PR DESCRIPTION
Temporarily sets overwrite to True when resuming a broken stage. Lead to the discovery and fix of a bug in settings.py, where nested settings context managers weren't supported. A unit test checking nested CMs should be created.