### PR TITLE
sphinx cross-referencing

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -87,7 +87,7 @@ jobs:
           name: Generate docs
           command: |
             . setup.env
-            SPHINXOPTS='-W' just sphinx build compile -n --all
+            SPHINXOPTS='-W --keep-going' just sphinx build compile -n --all
       - run:
           name: Smuggle docs back from remote docker
           command: |

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -43,8 +43,15 @@ extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.napoleon',
     'sphinx.ext.mathjax',
+    'sphinx.ext.intersphinx',
     'vsi_domains'
 ]
+
+# Link to other documentation (e.g., numpy, python, terra, etc.)
+intersphinx_mapping = {
+    'python': ('https://docs.python.org/3.6', None),
+    'vsi_common': ('https://visionsystemsinc.github.io/vsi_common/', None),
+}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']
@@ -82,52 +89,24 @@ napoleon_include_special_with_doc = True
 
 # Autodoc parameters
 
-autodoc_mock_imports = ["vsi",
-                        "vxl",
-                        "terra._terra",
+autodoc_mock_imports = [
+    "vsi",
+    "terra._terra",
+    "yaml",
+    "celery",
+]
 
-                        "envcontext",
-                        "yaml",
-                        "celery"]
-
-nitpick_ignore = [('py:class', 'bool'),
-                  ('py:class', 'array_like'),
-                  ('py:class', 'object'),
-                  ('py:class', 'str'),
-                  ('py:class', 'int'),
-                  ('py:class', 'float'),
-                  ('py:class', 'func'),
-                  ('py:class', 'dict'),
-                  ('py:class', 'iterable'),
-                  ('py:class', 'list'),
-                  ('py:class', 'class'),
-                  ('py:class', 'tuple'),
-                  ('py:class', 'module'),
-                  ('py:class', 'var'),
-                  ('py:class', 'file_like'),
-                  ('py:class', 'Exception'),
-                  ('py:class', 'type'),
-
-                  ('py:class', 'argparse.Action'),
-                  ('py:class', 'vsi.tools.python.BasicDecorator'),
-                  ('py:func',  'vsi.tools.python.nested_update'),
-
-                  ('py:mod',   'django.conf'),
-                  ('py:class', 'django.db.utils.ConnectionHandler'),
-
-                  ('py:class', 'weakref.WeakKeyDictionary'),
-                  ('py:class', 'json.encoder.JSONEncoder'),
-                  ('py:class', 'concurrent.futures._base.Executor'),
-                  ('py:class', 'concurrent.futures._base.Future'),
-                  ('py:class', 'argparse._AppendAction'),
-
-                  ('py:mod',   'logging'),
-                  ('py:data',  'logging.DEBUG'),
-                  ('py:data',  'logging.WARNING'),
-                  ('py:class', 'logging.Logger'),
-                  ('py:func',  'logging.debug'),
-
-                  ('py:exc',   'NotImplementedError')]
+nitpick_ignore = [
+    ('py:class', 'vsi.tools.python.BasicDecorator'),
+    ('py:mod',   'django.conf'),
+    ('py:class', 'django.db.utils.ConnectionHandler'),
+    ('py:class', 'json.encoder.JSONEncoder'),
+    ('py:class', 'concurrent.futures._base.Executor'),
+    ('py:class', 'concurrent.futures._base.Future'),
+    ('py:class', 'argparse._AppendAction'),
+    ('py:data',  'logging.DEBUG'),
+    ('py:data',  'logging.WARNING'),
+]
 
 # -- Options for HTML output -------------------------------------------------
 

--- a/terra/compute/utils.py
+++ b/terra/compute/utils.py
@@ -114,7 +114,7 @@ def load_service(name_or_class):
 
   Parameters
   ----------
-  name_or_class : :class:`str` or :class:`class` or instance
+  name_or_class : :class:`str` or :term:`class` or instance
       The service being loaded
 
   Returns

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -187,7 +187,7 @@ def settings_property(func):
 
   Arguments
   ---------
-  func : func
+  func : :term:`function`
       Function being decorated
   '''
 

--- a/terra/core/signals.py
+++ b/terra/core/signals.py
@@ -98,7 +98,7 @@ class Signal:
 
     Parameters
     ----------
-    receiver : func
+    receiver : :term:`function`
         A function or an instance method which is to receive signals.
         Receivers must be hashable objects.
         If weak is True, then receiver must be weak referenceable.
@@ -150,7 +150,7 @@ class Signal:
 
     Parameters
     ----------
-    receiver : func
+    receiver : :term:`function`
         The registered receiver to disconnect. May be none if
         dispatch_uid is specified.
     sender : object

--- a/terra/core/utils.py
+++ b/terra/core/utils.py
@@ -37,7 +37,7 @@ class cached_property:
 
   Parameters
   ----------
-  func : func
+  func : :term:`function`
       The function being wrapped
   name : :class:`str`, optional
       When not used as a decorator, allows you to make cached properties of


### PR DESCRIPTION
Add `intersphinx_mapping` to sphinx docs `conf.py`, allowing documentation to appropriately cross-reference against other documentation. Note this drastically reduces the necessary `nitpick_ignore` list and should make future documentation have fewer errors.

Add `--keep-going` to circleci `compile_docs` to make visible all sphinx errors (not just the first one). 