### PR TITLE
local_must_exist

### DIFF
--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -32,7 +32,18 @@ class BaseService:
                        check_remote=True,
                        local_must_exist=False):
     '''
-    Validate volume inputs
+    Validate volume inputs. Raise a :class:`ValueError` under any of the
+    following conditions:
+
+    - ``local`` is empty or None
+    - ``check_remote`` is True and ``remote`` is empty or None
+    - ``local_must_exist`` is True and ``local`` file/folder does not exist
+
+    Raises
+    ------
+    ValueError
+      see conditions above
+
     '''
 
     if not local:

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -28,10 +28,28 @@ class BaseService:
     self.volumes = []
     ''' A copy of the processes environment variables local to a service '''
 
-  def add_volume(self, local, remote, flags=None, prefix=None):
-    if local is None or remote is None:
-      return
+  def _validate_volume(self, local, remote,
+                       check_remote=True,
+                       local_must_exist=False):
+    '''
+    Validate volume inputs
+    '''
 
+    if not local:
+      raise ValueError('local file/folder must be specified')
+    elif check_remote and not remote:
+      raise ValueError('remote file/folder must be specified')
+    elif local_must_exist and not os.path.exists(local):
+      raise ValueError('local file/folder does not exist {}'
+                       .format(local))
+
+  def add_volume(self, local, remote, flags=None, prefix=None,
+                 local_must_exist=False):
+    '''
+    Add a volume to the service
+    '''
+
+    self._validate_volume(local, remote, local_must_exist=local_must_exist)
     self.volumes.append((local, remote))
 
   def get_volume_map(self, config, service_info):

--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -87,9 +87,13 @@ class ContainerService(BaseService):
     # self.temp_dir = None # Causes a warning, hopefully there wasn't a reason
     # I did it this way.
 
-  def add_volume(self, local, remote, flags=None, prefix=None):
-    if local is None or remote is None:
-      return
+  def add_volume(self, local, remote, flags=None, prefix=None,
+                 local_must_exist=False):
+    '''
+    Add a volume to the service
+    '''
+
+    self._validate_volume(local, remote, local_must_exist=local_must_exist)
 
     if self.container_platform == "windows":
       path = ntpath

--- a/terra/compute/virtualenv.py
+++ b/terra/compute/virtualenv.py
@@ -82,9 +82,15 @@ class Compute(BaseCompute):
     if pid.wait() != 0:
       raise ServiceRunFailed()
 
-  def add_volume(self, directory, no_remote=None, flags=None, prefix=None):
-    if directory is not None:
-      self.volumes.append(directory)
+  def add_volume(self, local, no_remote=None, flags=None, prefix=None,
+                 local_must_exist=False):
+    '''
+    Add a volume to the service
+    '''
+
+    self._validate_volume(local, None, check_remote=False,
+                          local_must_exist=local_must_exist)
+    self.volumes.append(local)
 
 
 class Service(BaseService):


### PR DESCRIPTION
New flag `local_must_exist` for service `add_volume()` to let users enforce local file/folder existence. 

Note that all `add_volume` functions now use `BaseService._validate_volume()` to validate the local and/or remote inputs, which now raises exceptions on invalid inputs.