### PR TITLE
Auto translate arguments to task functions

### DIFF
--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -82,8 +82,8 @@ class BaseService:
     # information is available. For example if using docker and celery, then
     # docker config need to be run to get the container volumes, and that has
     # to be run on the host machine. So this is calculated here.
-    settings.executor_volume_map = Executor.configuration_map(self)
-    logger.debug3("Executor Volume map: %s", settings.executor_volume_map)
+    settings.executor.volume_map = Executor.configuration_map(self)
+    logger.debug4("Executor Volume map: %s", settings.executor.volume_map)
 
   def post_run(self):
     pass

--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -58,9 +58,8 @@ class ContainerService(BaseService):
           volume_str
       env_volume_index += 1
 
-    volume_map = compute.configuration_map(self)
-
-    logger.debug3("Compute Volume map: %s", volume_map)
+    settings.compute.volume_map = compute.configuration_map(self)
+    logger.debug4("Compute Volume map: %s", settings.compute.volume_map)
 
     # Setup config file for container
 
@@ -68,7 +67,7 @@ class ContainerService(BaseService):
 
     container_config = translate_settings_paths(
         TerraJSONEncoder.serializableSettings(settings),
-        volume_map,
+        settings.compute.volume_map,
         self.container_platform)
 
     if os.name == "nt":  # pragma: no linux cover

--- a/terra/compute/utils.py
+++ b/terra/compute/utils.py
@@ -189,7 +189,7 @@ def just(*args, **kwargs):
   if logger.getEffectiveLevel() <= DEBUG1:
     dd = dict_diff(env, just_env)[3]
     if dd:
-      logger.debug1('Environment Modification:\n' + '\n'.join(dd))
+      logger.debug4('Environment Modification:\n' + '\n'.join(dd))
 
   # Get bash path for windows compatibility. I can't explain this error, but
   # while the PATH is set right, I can't call "bash" because the WSL bash is

--- a/terra/compute/virtualenv.py
+++ b/terra/compute/virtualenv.py
@@ -56,7 +56,7 @@ class Compute(BaseCompute):
     if logger.getEffectiveLevel() <= DEBUG1:
       dd = dict_diff(os.environ, env)[3]
       if dd:
-        logger.debug1('Environment Modification:\n' + '\n'.join(dd))
+        logger.debug4('Environment Modification:\n' + '\n'.join(dd))
 
     # Similar (but different) to a bug in docker compute, the right python
     # executable is not found on the path, possibly because Popen doesn't

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -263,13 +263,15 @@ global_templates = [
         "style": "%"
       },
       "executor": {
-        "type": "ThreadPoolExecutor"
+        "type": "ThreadPoolExecutor",
+        'volume_map': []
       },
       "compute": {
-        "arch": "terra.compute.dummy"
+        "arch": "terra.compute.dummy",
+        'volume_map': []
       },
       'terra': {
-        'zone': 'controller',
+        'zone': 'controller'
       },
       'status_file': status_file,
       'processing_dir': processing_dir,

--- a/terra/executor/dummy.py
+++ b/terra/executor/dummy.py
@@ -22,14 +22,16 @@ class DummyExecutor(Executor):
       if self._shutdown:
         raise RuntimeError('cannot schedule new futures after shutdown')
 
-      with settings:
-        settings.terra.zone = 'task'
-        f = Future()
-        logger.info(f'Run function: {fn}')
-        logger.info(f'With args: {args}')
-        logger.info(f'With kwargs: {kwargs}')
-        f.set_result(None)
-        return f
+      original_zone = settings.terra.zone
+      # Fake the zone for the log messages
+      settings.terra.zone = 'task'
+      f = Future()
+      logger.info(f'Run function: {fn}')
+      logger.info(f'With args: {args}')
+      logger.info(f'With kwargs: {kwargs}')
+      f.set_result(None)
+      settings.terra.zone = original_zone
+      return f
 
   def shutdown(self, wait=True):
     with self._shutdown_lock:

--- a/terra/executor/dummy.py
+++ b/terra/executor/dummy.py
@@ -1,6 +1,7 @@
 from concurrent.futures import Future, Executor
 from threading import Lock
 
+from terra import settings
 from terra.logger import getLogger
 logger = getLogger(__name__)
 
@@ -21,12 +22,14 @@ class DummyExecutor(Executor):
       if self._shutdown:
         raise RuntimeError('cannot schedule new futures after shutdown')
 
-      f = Future()
-      logger.info(f'Run function: {fn}')
-      logger.info(f'With args: {args}')
-      logger.info(f'With kwargs: {kwargs}')
-      f.set_result(None)
-      return f
+      with settings:
+        settings.terra.zone = 'task'
+        f = Future()
+        logger.info(f'Run function: {fn}')
+        logger.info(f'With args: {args}')
+        logger.info(f'With kwargs: {kwargs}')
+        f.set_result(None)
+        return f
 
   def shutdown(self, wait=True):
     with self._shutdown_lock:

--- a/terra/task.py
+++ b/terra/task.py
@@ -77,6 +77,7 @@ class TerraTask(Task):
     with open(env["TERRA_SETTINGS_FILE"], 'r') as fid:
       current_settings = json.load(fid)
     return super().apply_async(args=args, kwargs=kwargs,
+                               # use settings._wrapped instead of current_settings?
                                headers={'settings': current_settings},
                                task_id=task_id, *args2, **kwargs2)
 

--- a/terra/task.py
+++ b/terra/task.py
@@ -5,6 +5,8 @@ from tempfile import gettempdir
 
 from celery import Task, shared_task as original_shared_task
 
+from vsi.tools.python import args_to_kwargs, ARGS, KWARGS
+
 from terra import settings
 from terra.core.settings import TerraJSONEncoder
 from terra.executor import Executor
@@ -36,36 +38,67 @@ class TerraTask(Task):
   #     else:
   #       kwargs['settings'] = settings
 
-  def serialize_settings(self):
-    # If there is a non-empty mapping, then create a custom executor settings
-    executor_volume_map = self.request.settings.pop('executor_volume_map',
-                                                    None)
+  def _get_volume_mappings(self):
+    executor_volume_map = self.request.settings['executor']['volume_map']
+
     if executor_volume_map:
-      return terra.compute.utils.translate_settings_paths(
-          TerraJSONEncoder.serializableSettings(self.request.settings),
-          executor_volume_map)
-    return self.request.settings
+      reverse_compute_volume_map = \
+          self.request.settings['compute']['volume_map']
+      # Flip each mount point, so it goes from runner to controller
+      reverse_compute_volume_map = [[x[1], x[0]]
+                                    for x in reverse_compute_volume_map]
+      # Revere order. This will be important in case one mount point mounts
+      # inside another
+      reverse_compute_volume_map.reverse()
+    else:
+      reverse_compute_volume_map = []
 
-  def apply_async(self, args=None, kwargs=None, task_id=None, user=None,
+    return (reverse_compute_volume_map, executor_volume_map)
+
+  def translate_paths(self, payload, reverse_compute_volume_map,
+                      executor_volume_map):
+    if reverse_compute_volume_map or executor_volume_map:
+      # If either translation is needed, start by applying the ~ home dir
+      # expansion and settings_property(which wouldn't have made it through
+      # pure json conversion, but the ~ will
+      payload = TerraJSONEncoder.serializableSettings(payload)
+      # Go from compute runner to master controller
+      if reverse_compute_volume_map:
+        payload = terra.compute.utils.translate_settings_paths(
+            payload, reverse_compute_volume_map)
+      # Go from master controller to exector
+      if executor_volume_map:
+        payload = terra.compute.utils.translate_settings_paths(
+            payload, executor_volume_map)
+    return payload
+
+  def apply_async(self, args=None, kwargs=None, task_id=None,
                   *args2, **kwargs2):
-    with open(f'{env["TERRA_SETTINGS_FILE"]}.orig', 'r') as fid:
-      original_settings = json.load(fid)
+    with open(env["TERRA_SETTINGS_FILE"], 'r') as fid:
+      current_settings = json.load(fid)
     return super().apply_async(args=args, kwargs=kwargs,
-                               task_id=task_id, *args2, headers={'settings': original_settings},
-                               **kwargs2)
+                               headers={'settings': current_settings},
+                               task_id=task_id, *args2, **kwargs2)
 
+  # Don't need to apply translations for apply, it runs locally
   # def apply(self, *args, **kwargs):
   #   # TerraTask._patch_settings(args, kwargs)
   #   return super().apply(*args, settings={'X': 15}, **kwargs)
 
   def __call__(self, *args, **kwargs):
+    # this is only set when apply_async was called.
     if getattr(self.request, 'settings', None):
       if not settings.configured:
+        # Cover a potential (unlikely) corner case where setting might not be
+        # configured yet
         settings.configure({'processing_dir': gettempdir()})
       with settings:
-        logger.critical(settings)
+        reverse_compute_volume_map, executor_volume_map = \
+            self._get_volume_mappings()
+
         settings._wrapped.clear()
-        settings._wrapped.update(self.serialize_settings())
+        settings._wrapped.update(self.translate_paths(self.request.settings,
+            reverse_compute_volume_map, executor_volume_map))
         if not os.path.exists(settings.processing_dir):
           logger.critical(f'Dir "{settings.processing_dir}" is not accessible '
                           'by the executor, please make sure the worker has '
@@ -73,10 +106,14 @@ class TerraTask(Task):
           settings.processing_dir = gettempdir()
           logger.warning('Using temporary directory: '
                          f'"{settings.processing_dir}" for the processing dir')
-        logger.critical(settings)
         settings.terra.zone = 'task'
+        kwargs = args_to_kwargs(self.run, args, kwargs)
+        args_only = kwargs.pop(ARGS, ())
+        kwargs.update(kwargs.pop(KWARGS, ()))
+        kwargs = self.translate_paths(kwargs,
+            reverse_compute_volume_map, executor_volume_map)
         terra.logger._logs.reconfigure_logger()
-        return_value = self.run(*args, **kwargs)
+        return_value = self.run(*args_only, **kwargs)
     else:
       original_zone = settings.terra.zone
       settings.terra.zone = 'task'


### PR DESCRIPTION
- Now executor settings are auto translated from runner to exectutor,
  instead of from master controller to executor. This clears the path to
  more consistent behavior when it comes to passing in arguments.
- Task args and kwargs that match the same suffix patterns settings so,
  will now be auto translated from runner to task. This should make for
  a more seemless transaction to task, as long as the variable names are
  right.
- Executor and compute both have a volume map store in the settings now.