### PR TITLE
Return values in celery get volume translations

### DIFF
--- a/terra.env
+++ b/terra.env
@@ -79,9 +79,13 @@ fi
 #**
 # .. envvar:: TERRA_CELERY_MAIN_NAME
 #
-# Name of the main module if running as __main__. This is used as the prefix for auto-generated task names.
+# (Optional) Name of the main module if running as __main__. This is used as the prefix for auto-generated task names that are defined in the same module as ``__main__`` (Usually caused by ``python -m``). At first, python will try ``sys.modules['__main__'].__spec__.name``, before using this value, when that fails.
+#
+# .. envvar:: TERRA_KEEP_TEMP_DIR
+#
+# Optional environment variable, that when set to ``1`` will keep the temporary config files generated for containers. For debug use.
 #**
-: ${TERRA_CELERY_MAIN_NAME=terra}
+
 #**
 # .. envvar:: TERRA_CELERY_CONF
 #

--- a/terra/compute/docker.py
+++ b/terra/compute/docker.py
@@ -96,7 +96,9 @@ class Compute(BaseCompute):
           ans = re.match(docker_volume_re, volume).groups()
           volume_map.append((ans[0], ans[2]))
 
-    volume_map = volume_map + service_info.volumes
+    # This is not needed, because service_info.volumes are already in
+    # service_info.env, added by terra.compute.base.BaseService.pre_run
+    # volume_map = volume_map + service_info.volumes
 
     slashes = '/'
     if os.name == 'nt':

--- a/terra/compute/singularity.py
+++ b/terra/compute/singularity.py
@@ -72,7 +72,8 @@ class Compute(BaseCompute):
       volume = volume.split(':')
       volume_map.append((volume[0], volume[1]))
 
-    volume_map = volume_map + service_info.volumes
+    # I think this causes duplicates, just like in the docker
+    # volume_map = volume_map + service_info.volumes
 
     slashes = '/'
     if os.name == 'nt':

--- a/terra/compute/virtualenv.py
+++ b/terra/compute/virtualenv.py
@@ -105,7 +105,9 @@ class Service(BaseService):
     super().pre_run()
 
     # Create a temp directory, store it in this instance
-    self.temp_dir = TemporaryDirectory()
+    self.temp_dir = TemporaryDirectory(suffix=f"_{type(self).__name__}")
+    if env.get('TERRA_KEEP_TEMP_DIR', None) == "1":
+      self.temp_dir._finalizer.detach()
 
     # Use a config.json file to store settings within that temp directory
     temp_config_file = os.path.join(self.temp_dir.name, 'config.json')
@@ -124,4 +126,5 @@ class Service(BaseService):
   def post_run(self):
     super().post_run()
     # Delete temp_dir
-    self.temp_dir.cleanup()
+    if env.get('TERRA_KEEP_TEMP_DIR', None) != "1":
+      self.temp_dir.cleanup()

--- a/terra/executor/celery/__init__.py
+++ b/terra/executor/celery/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import sys
 from os import environ as env
 
 from celery import Celery
@@ -10,7 +11,15 @@ logger = getLogger(__name__)
 
 __all__ = ['CeleryExecutor']
 
-app = Celery(env['TERRA_CELERY_MAIN_NAME'])
+
+main_name = env.get('TERRA_CELERY_MAIN_NAME', None)
+if main_name is None:
+  try:
+    main_name = sys.modules['__main__'].__spec__.name
+  except:
+    main_name = "main_name_unset_Set_TERRA_CELERY_MAIN_NAME"
+app = Celery(main_name)
+
 app.config_from_object(env['TERRA_CELERY_CONF'])
 
 # app.running = False


### PR DESCRIPTION
- Temporary directors have a meaningful suffix
- TERRA_KEEP_TEMP_DIR added for debuging
- TERRA_CELERY_MAIN_NAME is automatic now
- config.json.orig removed, as no longer needed
- Fixed a duplicate volume_map bug

Signed-off-by: Andy Neff <andy@visionsystemsinc.com>