### PR TITLE
update password mask

### DIFF
--- a/terra.env
+++ b/terra.env
@@ -72,8 +72,8 @@ fi
 
 if [[ ! -f /.dockerenv && ! -s "${TERRA_REDIS_SECRET_FILE}" ]]; then
   source "${VSI_COMMON_DIR}/linux/random.bsh"
-  # No quotes allowed
-  urandom_password 20 '\x21\x23-\x26\x28-\x7E' > "${TERRA_REDIS_SECRET_FILE}"
+  # Allow printable ascii characters excpet quotes, ';' (for an unknown redis/celery parsing reason), ':' or '@' (for redis url reasons)
+  urandom_password 20 '\x21\x23-\x26\x28-\x39\x3c-\x3f\x41-\x7E' > "${TERRA_REDIS_SECRET_FILE}"
 fi
 
 #**


### PR DESCRIPTION
Disallow certain characters in the randomly generated passwords used for redis/celery: `;` (for an unknown redis/celery parsing reason), `:` or `@` (for redis url parsing reasons)