### PR TITLE
Celery

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -130,6 +130,13 @@ function terra_caseify()
       Terra_Pipenv run celery -A terra.executor.celery.app worker --loglevel="${TERRA_CELLER_LOG_LEVEL-INFO}" -n "${node_name}"
       ;;
 
+    run_flower) # Start the flower server
+      Terra_Pipenv run celery -A terra.executor.celery.app flower
+      ;;
+    shutdown_celery) # Shuts down all celery works on all nodes
+      Terra_Pipenv run python -c "from terra.executor.celery import app; app.control.broadcast('shutdown')"
+      ;;
+
     ### Run Debugging containers ###
     generate-redis-commander-hash) # Generate a redis commander hash
       touch "${TERRA_REDIS_COMMANDER_SECRET_FILE}"

--- a/Justfile
+++ b/Justfile
@@ -31,7 +31,8 @@ function Terra_Pipenv()
     if [ -n "${VIRTUAL_ENV+set}" ]; then
       echo "Warning: You appear to be in a virtual env" >&2
       echo "Deactivate external virtual envs before running just" >&2
-      ask_question "Continue?" n
+      ask_question "Continue?" answer_continue n
+      [ "$answer_continue" == "0" ] && return 1
     fi
     PIPENV_PIPFILE="${TERRA_CWD}/Pipfile" pipenv ${@+"${@}"} || return $?
   else
@@ -120,10 +121,6 @@ function terra_caseify()
       extra_args=$#
       ;;
 
-    run_redis) # Run redis
-      Just-docker-compose -f "${TERRA_CWD}/docker-compose.yml" run redis ${@+"${@}"}
-      extra_args=$#
-      ;;
     run_celery) # Starts a celery worker
       local node_name
       if [[ ${TERRA_LOCAL-} == 1 ]]; then
@@ -140,11 +137,11 @@ function terra_caseify()
       fi
 
       # We might be able to use CELERY_LOADER to avoid the -A argument
-      TERRA_IS_CELERY_WORKER=1 Terra_Pipenv run python -m terra.executor.celery -A terra.executor.celery.app worker --loglevel="${TERRA_CELLER_LOG_LEVEL-INFO}" -n "${node_name}"
+      Terra_Pipenv run python -m terra.executor.celery -A terra.executor.celery.app worker --loglevel="${TERRA_CELERY_LOG_LEVEL-INFO}" -n "${node_name}"
       ;;
 
     run_flower) # Start the flower server
-      Terra_Pipenv run celery -A terra.executor.celery.app flower
+      Terra_Pipenv run python -m terra.executor.celery -A terra.executor.celery.app flower
       ;;
     shutdown_celery) # Shuts down all celery works on all nodes
       Terra_Pipenv run python -c "from terra.executor.celery import app; app.control.broadcast('shutdown')"
@@ -223,7 +220,8 @@ function terra_caseify()
     terra_test-pep8) # Run pep8 test
       justify terra pep8
       echo "Running flake8..."
-      Terra_Pipenv run bash -c 'flake8 \
+      Terra_Pipenv run bash -c 'cd ${TERRA_TERRA_DIR};
+                                flake8 \
                                 "${TERRA_TERRA_DIR}/terra"'
       ;;
 

--- a/Justfile
+++ b/Justfile
@@ -127,7 +127,14 @@ function terra_caseify()
         node_name="docker@%h"
       fi
 
-      Terra_Pipenv run celery -A terra.executor.celery.app worker --loglevel="${TERRA_CELLER_LOG_LEVEL-INFO}" -n "${node_name}"
+      # Untested
+      if [ "${OS-}" = "Windows_NT" ]; then
+        # https://www.distributedpython.com/2018/08/21/celery-4-windows/
+        local FORKED_BY_MULTIPROCESSING
+        export FORKED_BY_MULTIPROCESSING=1
+      fi
+
+      TERRA_IS_CELERY_WORKER=1 Terra_Pipenv run celery -A terra.executor.celery.app worker --loglevel="${TERRA_CELLER_LOG_LEVEL-INFO}" -n "${node_name}"
       ;;
 
     run_flower) # Start the flower server

--- a/Justfile
+++ b/Justfile
@@ -139,7 +139,8 @@ function terra_caseify()
         export FORKED_BY_MULTIPROCESSING=1
       fi
 
-      TERRA_IS_CELERY_WORKER=1 Terra_Pipenv run celery -A terra.executor.celery.app worker --loglevel="${TERRA_CELLER_LOG_LEVEL-INFO}" -n "${node_name}"
+      # We might be able to use CELERY_LOADER to avoid the -A argument
+      TERRA_IS_CELERY_WORKER=1 Terra_Pipenv run python -m terra.executor.celery -A terra.executor.celery.app worker --loglevel="${TERRA_CELLER_LOG_LEVEL-INFO}" -n "${node_name}"
       ;;
 
     run_flower) # Start the flower server

--- a/Justfile
+++ b/Justfile
@@ -28,6 +28,11 @@ JUST_DEFAULTIFY_FUNCTIONS+=(terra_caseify)
 function Terra_Pipenv()
 {
   if [[ ${TERRA_LOCAL-} == 1 ]]; then
+    if [ -n "${VIRTUAL_ENV+set}" ]; then
+      echo "Warning: You appear to be in a virtual env" >&2
+      echo "Deactivate external virtual envs before running just" >&2
+      ask_question "Continue?" n
+    fi
     PIPENV_PIPFILE="${TERRA_CWD}/Pipfile" pipenv ${@+"${@}"} || return $?
   else
     Just-docker-compose -f "${TERRA_CWD}/docker-compose-main.yml" run ${TERRA_PIPENV_IMAGE-terra} pipenv ${@+"${@}"} || return $?

--- a/README.md
+++ b/README.md
@@ -17,3 +17,13 @@ source 'setup.env'
 just terra sync
 just terra run
 ```
+
+## Running an app in celery
+
+1. `just terra up` - To start redis queue (only once)
+2. `just run celery` - To start a celery worker (run on each worker node)
+3. `just run dsm ...` - To start processing job
+
+When done
+4. `just shutdown celery` - To shutdown _all_ celery workers on _all_ nodes
+5. `just terra down` - To shutdown redis.

--- a/docker-compose-main.yml
+++ b/docker-compose-main.yml
@@ -6,7 +6,7 @@ services:
       dockerfile: docker/terra.Dockerfile
     # prevent different users from clobbering each others images
     image: ${TERRA_DOCKER_REPO}:terra_${TERRA_USERNAME}
-    environment:
+    environment: &terra_environment
       # Variables for docker_entrypoint.bsh
       - DOCKER_UID=${TERRA_UID}
       - DOCKER_GIDS=${TERRA_GIDS}
@@ -17,6 +17,7 @@ services:
       - JUST_SETTINGS=${TERRA_TERRA_DIR_DOCKER}/terra.env
       - PYTHONPATH=${TERRA_PYTHONPATH-}
       - TZ
+      - TERRA_IS_CELERY_WORKER=${TERRA_IS_CELERY_WORKER-0}
     cap_add:
       - SYS_PTRACE # Useful for gdb
     volumes:

--- a/docker-compose-main.yml
+++ b/docker-compose-main.yml
@@ -8,16 +8,15 @@ services:
     image: ${TERRA_DOCKER_REPO}:terra_${TERRA_USERNAME}
     environment: &terra_environment
       # Variables for docker_entrypoint.bsh
-      - DOCKER_UID=${TERRA_UID}
-      - DOCKER_GIDS=${TERRA_GIDS}
-      - DOCKER_GROUP_NAMES=${TERRA_GROUP_NAMES}
-      - DOCKER_USERNAME=user
-      - DISPLAY
-      - JUSTFILE=${TERRA_TERRA_DIR_DOCKER}/docker/terra.Justfile
-      - JUST_SETTINGS=${TERRA_TERRA_DIR_DOCKER}/terra.env
-      - PYTHONPATH=${TERRA_PYTHONPATH-}
-      - TZ
-      - TERRA_IS_CELERY_WORKER=${TERRA_IS_CELERY_WORKER-0}
+      DOCKER_UID: ${TERRA_UID}
+      DOCKER_GIDS: ${TERRA_GIDS}
+      DOCKER_GROUP_NAMES: ${TERRA_GROUP_NAMES}
+      DOCKER_USERNAME: user
+      JUSTFILE: ${TERRA_TERRA_DIR_DOCKER}/docker/terra.Justfile
+      JUST_SETTINGS: ${TERRA_TERRA_DIR_DOCKER}/terra.env
+      PYTHONPATH: ${TERRA_PYTHONPATH-}
+      DISPLAY:
+      TZ:
     cap_add:
       - SYS_PTRACE # Useful for gdb
     volumes:
@@ -39,6 +38,12 @@ services:
         source: terra-venv
         target: /venv
 
+  terra-demo:
+    <<: *terra
+    environment:
+      <<: *terra_environment
+      TERRA_SETTINGS_FILE:
+
   redis-commander:
     image: rediscommander/redis-commander
     ports:
@@ -47,14 +52,14 @@ services:
       - source: redis_secret
         target: ${TERRA_REDIS_SECRET_DOCKER}
       - source: redis_commander_secret
-        target: ${TERRA_REDIS_COMMANDER_SECRET_FILE}
+        target: ${TERRA_REDIS_COMMANDER_SECRET}
     command: |
       sh -c '
         echo -n '"'"'{
           "connections":[
             {
               "password": "'"'"' > /redis-commander/config/local-production.json
-        cat /run/secrets/redis_password | sed '"'"'s|\\|\\\\|g;s|"|\\"|g'"'"' >> /redis-commander/config/local-production.json
+        cat /run/secrets/${TERRA_REDIS_SECRET_DOCKER} | sed '"'"'s|\\|\\\\|g;s|"|\\"|g'"'"' >> /redis-commander/config/local-production.json
         echo -n '"'"'",
               "host": "${TERRA_REDIS_HOSTNAME_DOCKER}",
               "label": "terra",
@@ -69,7 +74,7 @@ services:
             "httpAuth": {
               "username": "admin",
               "passwordHash": "'"'"'>> /redis-commander/config/local-production.json
-          cat "/run/secrets/${TERRA_REDIS_COMMANDER_SECRET_FILE}" | sed '"'"'s|\\|\\\\|g;s|"|\\"|g'"'"' >> /redis-commander/config/local-production.json
+          cat "/run/secrets/${TERRA_REDIS_COMMANDER_SECRET}" | sed '"'"'s|\\|\\\\|g;s|"|\\"|g'"'"' >> /redis-commander/config/local-production.json
           echo '"'"'"
             }
           }

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -51,6 +51,7 @@ extensions = [
 intersphinx_mapping = {
     'python': ('https://docs.python.org/3.6', None),
     'vsi_common': ('https://visionsystemsinc.github.io/vsi_common/', None),
+    'celery': ('https://docs.celeryproject.org/en/stable/', None)
 }
 
 # Add any paths that contain templates here, relative to this directory.
@@ -103,6 +104,8 @@ nitpick_ignore = [
     ('py:class', 'json.encoder.JSONEncoder'),
     ('py:class', 'concurrent.futures._base.Executor'),
     ('py:class', 'concurrent.futures._base.Future'),
+    ('py:class', 'concurrent.futures.process.ProcessPoolExecutor'),
+    ('py:class', 'concurrent.futures.thread.ThreadPoolExecutor'),
     ('py:class', 'argparse._AppendAction'),
     ('py:data',  'logging.DEBUG'),
     ('py:data',  'logging.WARNING'),

--- a/docs/terra/settings.rst
+++ b/docs/terra/settings.rst
@@ -1,6 +1,19 @@
 
 .. _settings:
 
+Terra Settings
+--------------
+
+.. option:: terra.zone
+
+    Terra can be running in one of three areas of execution, or "zones": the master controller (``controller``), a service runner (``runner``), or a task (``task``). The different zones could all be running on the main host, or other containers or computers, depending on the compute and executor.
+
+    The master controller includes: the CLI, workflow, stage and service definitions layers.
+
+    This variable is automatically updated, and should only be read.
+
+    Default: ``controller``
+
 Workflow Settings
 -----------------
 

--- a/setup.py
+++ b/setup.py
@@ -11,6 +11,8 @@ setup(name="terra",
       extra_requires=extra_requires,
       install_requires=[
         "jstyleson",
-        "envcontext"
+        "envcontext",
+        # I use signal and task from celery, no matter what
+        "celery"
       ]
 )

--- a/terra.env
+++ b/terra.env
@@ -72,8 +72,8 @@ fi
 
 if [[ ! -f /.dockerenv && ! -s "${TERRA_REDIS_SECRET_FILE}" ]]; then
   source "${VSI_COMMON_DIR}/linux/random.bsh"
-  # No quotes allowed
-  urandom_password 20 '\x21\x23-\x26\x28-\x7E' > "${TERRA_REDIS_SECRET_FILE}"
+  # Allow printable ascii characters excpet quotes, ';' (for an unknown redis/celery parsing reason), ':' or '@' (for redis url reasons)
+  urandom_password 20 '\x21\x23-\x26\x28-\x39\x3c-\x3f\x41-\x7E' > "${TERRA_REDIS_SECRET_FILE}"
 fi
 
 #**

--- a/terra.env
+++ b/terra.env
@@ -79,9 +79,13 @@ fi
 #**
 # .. envvar:: TERRA_CELERY_MAIN_NAME
 #
-# Name of the main module if running as __main__. This is used as the prefix for auto-generated task names.
+# (Optional) Name of the main module if running as __main__. This is used as the prefix for auto-generated task names that are defined in the same module as ``__main__`` (Usually caused by ``python -m``). At first, python will try ``sys.modules['__main__'].__spec__.name``, before using this value, when that fails.
+#
+# .. envvar:: TERRA_KEEP_TEMP_DIR
+#
+# Optional environment variable, that when set to ``1`` will keep the temporary config files generated for containers. For debug use.
 #**
-: ${TERRA_CELERY_MAIN_NAME=terra}
+
 #**
 # .. envvar:: TERRA_CELERY_CONF
 #

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -82,8 +82,8 @@ class BaseService:
     # information is available. For example if using docker and celery, then
     # docker config need to be run to get the container volumes, and that has
     # to be run on the host machine. So this is calculated here.
-    settings.executor_volume_map = Executor.configuration_map(self)
-    logger.debug3("Executor Volume map: %s", settings.executor_volume_map)
+    settings.executor.volume_map = Executor.configuration_map(self)
+    logger.debug4("Executor Volume map: %s", settings.executor.volume_map)
 
   def post_run(self):
     pass

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -1,10 +1,17 @@
 import os
-import json
+import time
+import atexit
+from logging import StreamHandler
+from logging.handlers import SocketHandler
+import threading
+import warnings
 
 from terra import settings
 import terra.compute.utils
 from terra.executor import Executor
-from terra.logger import getLogger
+from terra.logger import (
+  getLogger, LogRecordSocketReceiver, SkipStdErrAddFilter
+)
 logger = getLogger(__name__)
 
 
@@ -64,9 +71,6 @@ class BaseService:
 
     self._validate_volume(local, remote, local_must_exist=local_must_exist)
     self.volumes.append((local, remote))
-
-  def get_volume_map(self, config, service_info):
-    return []
 
   def pre_run(self):
     '''
@@ -164,6 +168,9 @@ class BaseCompute:
     # bind function and return it
     return defaultCommand.__get__(self, type(self))
 
+  def get_volume_map(self, config, service_info):
+    return []
+
   def run_service(self, *args, **kwargs):
     '''
     Place holder for code to run an instance in the compute. Runs
@@ -185,6 +192,90 @@ class BaseCompute:
     '''
 
     return service_info.volumes
+
+  @staticmethod
+  def configure_logger(sender, **kwargs):
+    if settings.terra.zone == 'controller':
+      # Setup log file for use in configure
+      sender._log_file = os.path.join(
+          settings.processing_dir,
+          terra.logger._SetupTerraLogger.default_log_prefix)
+      os.makedirs(settings.processing_dir, exist_ok=True)
+      sender._log_file = open(sender._log_file, 'a')
+      sender.main_log_handler = StreamHandler(stream=sender._log_file)
+      sender.root_logger.addHandler(sender.main_log_handler)
+
+      # setup the TCP socket listener
+      sender.tcp_logging_server = LogRecordSocketReceiver(
+          settings.logging.server.hostname, settings.logging.server.port)
+      listener_thread = threading.Thread(
+          target=sender.tcp_logging_server.serve_until_stopped)
+      listener_thread.setDaemon(True)
+      listener_thread.start()
+
+      # Wait up to a second, to make sure the thread started
+      for _ in range(1000):
+        if sender.tcp_logging_server.ready:
+          break
+        time.sleep(0.001)
+      else:  # pragma: no cover
+        warnings.warn("TCP Logging server thread did not startup. "
+                      "This is probably not a problem, unless logging isn't "
+                      "working.", RuntimeWarning)
+
+      # Auto cleanup
+      @atexit.register
+      def cleanup_thread():
+        sender.tcp_logging_server.abort = 1
+        listener_thread.join(timeout=5)
+        if listener_thread.is_alive():  # pragma: no cover
+          warnings.warn("TCP Logger Server Thread did not shut down "
+                        "gracefully. Attempting to exit anyways.",
+                        RuntimeWarning)
+    elif settings.terra.zone == 'runner':
+      sender.main_log_handler = SocketHandler(
+          settings.logging.server.hostname, settings.logging.server.port)
+      # By default, all runners have access to the master controllers stderr,
+      # so there is no need for the master controller to echo out the log
+      # messages a second time.
+      sender.main_log_handler.addFilter(SkipStdErrAddFilter())
+      sender.root_logger.addHandler(sender.main_log_handler)
+
+  @staticmethod
+  def reconfigure_logger(sender, **kwargs):
+    # sender is logger in this case
+    #
+    # The default logging handler is a StreamHandler. This will reconfigure its
+    # output stream
+
+    if settings.terra.zone == 'controller':
+      log_file = os.path.join(
+          settings.processing_dir,
+          terra.logger._SetupTerraLogger.default_log_prefix)
+
+      # Check to see if _log_file is unset. If it is, this is due to _log_file
+      # being called without configure being called. While it is not important
+      # this work, it's more likely for unit testsing
+      # if not os.path.samefile(log_file, sender._log_file.name):
+      if getattr(sender, '_log_file', None) is not None and \
+         log_file != sender._log_file.name:
+        os.makedirs(settings.processing_dir, exist_ok=True)
+        sender._log_file.close()
+        sender._log_file = open(log_file, 'a')
+    elif settings.terra.zone == 'runner':
+      # Only if it's changed
+      if settings.logging.server.hostname != sender.main_log_handler.host or \
+         settings.logging.server.port != sender.main_log_handler.port:
+        # Reconnect Socket Handler
+        sender.main_log_handler.close()
+        try:
+          sender.root_logger.removeHandler(sender.main_log_handler)
+        except ValueError:  # pragma: no cover
+          pass
+
+        sender.main_log_handler = SocketHandler(
+            settings.logging.server.hostname, settings.logging.server.port)
+        sender.root_logger.addHandler(sender.main_log_handler)
 
 
 services = {}

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -83,8 +83,7 @@ class BaseService:
     # docker config need to be run to get the container volumes, and that has
     # to be run on the host machine. So this is calculated here.
     settings.executor_volume_map = Executor.configuration_map(self)
-    logger.critical(settings.executor_volume_map)
-
+    logger.debug3("Executor Volume map: %s", settings.executor_volume_map)
 
   def post_run(self):
     pass

--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -58,9 +58,8 @@ class ContainerService(BaseService):
           volume_str
       env_volume_index += 1
 
-    volume_map = compute.configuration_map(self)
-
-    logger.debug3("Compute Volume map: %s", volume_map)
+    settings.compute.volume_map = compute.configuration_map(self)
+    logger.debug4("Compute Volume map: %s", settings.compute.volume_map)
 
     # Setup config file for container
 
@@ -68,7 +67,7 @@ class ContainerService(BaseService):
 
     container_config = translate_settings_paths(
         TerraJSONEncoder.serializableSettings(settings),
-        volume_map,
+        settings.compute.volume_map,
         self.container_platform)
 
     if os.name == "nt":  # pragma: no linux cover

--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -79,6 +79,7 @@ class ContainerService(BaseService):
           + '|TERRA_SETTINGS_FILE'
 
     # Dump the settings
+    container_config['terra']['zone'] = 'runner'
     with open(temp_dir / 'config.json', 'w') as fid:
       json.dump(container_config, fid)
 

--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -29,6 +29,10 @@ class ContainerService(BaseService):
     self.extra_compose_files = []
 
   def pre_run(self):
+    # Need to run Base's pre_run first, so it has a change to update settings
+    # for special exectutors, etc...
+    super().pre_run()
+
     self.temp_dir = TemporaryDirectory()
     temp_dir = pathlib.Path(self.temp_dir.name)
 
@@ -78,7 +82,10 @@ class ContainerService(BaseService):
     with open(temp_dir / 'config.json', 'w') as fid:
       json.dump(container_config, fid)
 
-    super().pre_run()
+    # Dump the original setting too, incase an executor needs to perform map
+    # translation too
+    with open(temp_dir / 'config.json.orig', 'w') as fid:
+      json.dump(TerraJSONEncoder.serializableSettings(settings), fid)
 
   def post_run(self):
     super().post_run()

--- a/terra/compute/docker.py
+++ b/terra/compute/docker.py
@@ -42,7 +42,7 @@ class Compute(BaseCompute):
 
         just --wrap Just-docker-compose \\
             -f {service_info.compose_files} ... \\
-            run {service_info.compose_service_name} \\
+            run -T {service_info.compose_service_name} \\
             {service_info.command}
     '''
     optional_args = {}
@@ -50,7 +50,7 @@ class Compute(BaseCompute):
 
     pid = just("--wrap", "Just-docker-compose",
                *sum([['-f', cf] for cf in service_info.compose_files], []),
-               'run', service_info.compose_service_name,
+               'run', '-T', service_info.compose_service_name,
                *service_info.command + extra_arguments,
                **optional_args,
                env=service_info.env)

--- a/terra/compute/docker.py
+++ b/terra/compute/docker.py
@@ -96,7 +96,9 @@ class Compute(BaseCompute):
           ans = re.match(docker_volume_re, volume).groups()
           volume_map.append((ans[0], ans[2]))
 
-    volume_map = volume_map + service_info.volumes
+    # This is not needed, because service_info.volumes are already in
+    # service_info.env, added by terra.compute.base.BaseService.pre_run
+    # volume_map = volume_map + service_info.volumes
 
     slashes = '/'
     if os.name == 'nt':

--- a/terra/compute/singularity.py
+++ b/terra/compute/singularity.py
@@ -72,7 +72,8 @@ class Compute(BaseCompute):
       volume = volume.split(':')
       volume_map.append((volume[0], volume[1]))
 
-    volume_map = volume_map + service_info.volumes
+    # I think this causes duplicates, just like in the docker
+    # volume_map = volume_map + service_info.volumes
 
     slashes = '/'
     if os.name == 'nt':

--- a/terra/compute/utils.py
+++ b/terra/compute/utils.py
@@ -189,7 +189,7 @@ def just(*args, **kwargs):
   if logger.getEffectiveLevel() <= DEBUG1:
     dd = dict_diff(env, just_env)[3]
     if dd:
-      logger.debug1('Environment Modification:\n' + '\n'.join(dd))
+      logger.debug4('Environment Modification:\n' + '\n'.join(dd))
 
   # Get bash path for windows compatibility. I can't explain this error, but
   # while the PATH is set right, I can't call "bash" because the WSL bash is

--- a/terra/compute/utils.py
+++ b/terra/compute/utils.py
@@ -40,6 +40,7 @@ from vsi.tools.diff import dict_diff
 from vsi.tools.python import nested_patch
 
 from terra.core.utils import Handler
+import terra.core.signals
 from terra import settings
 import terra.compute.base
 from terra.core.settings import filename_suffixes
@@ -92,6 +93,12 @@ compute = ComputeHandler()
 For the most part, workflows will be interacting with :data:`compute` to
 ``run`` services. Easier access via ``terra.compute.compute``
 '''
+terra.core.signals.logger_configure.connect(
+    lambda *args, **kwargs: compute.configure_logger(*args, **kwargs),
+    weak=False)
+terra.core.signals.logger_reconfigure.connect(
+    lambda *args, **kwargs: compute.reconfigure_logger(*args, **kwargs),
+    weak=False)
 
 
 def get_default_service_class(cls):

--- a/terra/compute/virtualenv.py
+++ b/terra/compute/virtualenv.py
@@ -106,18 +106,19 @@ class Service(BaseService):
 
     # Create a temp directory, store it in this instance
     self.temp_dir = TemporaryDirectory(suffix=f"_{type(self).__name__}")
-    if env.get('TERRA_KEEP_TEMP_DIR', None) == "1":
+    if self.env.get('TERRA_KEEP_TEMP_DIR', None) == "1":
       self.temp_dir._finalizer.detach()
 
     # Use a config.json file to store settings within that temp directory
     temp_config_file = os.path.join(self.temp_dir.name, 'config.json')
 
     # Serialize config file
-    docker_config = TerraJSONEncoder.serializableSettings(settings)
+    venv_config = TerraJSONEncoder.serializableSettings(settings)
 
     # Dump the serialized config to the temp config file
+    venv_config['terra']['zone'] = 'runner'
     with open(temp_config_file, 'w') as fid:
-      json.dump(docker_config, fid)
+      json.dump(venv_config, fid)
 
     # Set the Terra settings file for this service runner to the temp config
     # file
@@ -126,5 +127,5 @@ class Service(BaseService):
   def post_run(self):
     super().post_run()
     # Delete temp_dir
-    if env.get('TERRA_KEEP_TEMP_DIR', None) != "1":
+    if self.env.get('TERRA_KEEP_TEMP_DIR', None) != "1":
       self.temp_dir.cleanup()

--- a/terra/compute/virtualenv.py
+++ b/terra/compute/virtualenv.py
@@ -56,7 +56,7 @@ class Compute(BaseCompute):
     if logger.getEffectiveLevel() <= DEBUG1:
       dd = dict_diff(os.environ, env)[3]
       if dd:
-        logger.debug1('Environment Modification:\n' + '\n'.join(dd))
+        logger.debug4('Environment Modification:\n' + '\n'.join(dd))
 
     # Similar (but different) to a bug in docker compute, the right python
     # executable is not found on the path, possibly because Popen doesn't

--- a/terra/compute/virtualenv.py
+++ b/terra/compute/virtualenv.py
@@ -105,7 +105,9 @@ class Service(BaseService):
     super().pre_run()
 
     # Create a temp directory, store it in this instance
-    self.temp_dir = TemporaryDirectory()
+    self.temp_dir = TemporaryDirectory(suffix=f"_{type(self).__name__}")
+    if env.get('TERRA_KEEP_TEMP_DIR', None) == "1":
+      self.temp_dir._finalizer.detach()
 
     # Use a config.json file to store settings within that temp directory
     temp_config_file = os.path.join(self.temp_dir.name, 'config.json')
@@ -124,4 +126,5 @@ class Service(BaseService):
   def post_run(self):
     super().post_run()
     # Delete temp_dir
-    self.temp_dir.cleanup()
+    if env.get('TERRA_KEEP_TEMP_DIR', None) != "1":
+      self.temp_dir.cleanup()

--- a/terra/core/exceptions.py
+++ b/terra/core/exceptions.py
@@ -2,3 +2,9 @@ class ImproperlyConfigured(Exception):
   """
   Exception for Terra is somehow improperly configured
   """
+
+
+class ConfigurationWarning(Warning):
+  """
+  Warning for Terra may somehow be improperly configured
+  """

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -693,7 +693,7 @@ class TerraJSONEncoder(JSONEncoder):
 
     obj = nested_patch(
         obj,
-        lambda k, v: any(v is not None and k.endswith(pattern) for pattern in filename_suffixes),
+        lambda k, v: any(v is not None and isinstance(k, str) and k.endswith(pattern) for pattern in filename_suffixes),
         lambda k, v: os.path.expanduser(v))
 
     return obj

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -258,7 +258,7 @@ global_templates = [
     {
       "logging": {
         "level": "ERROR",
-        "format": f"%(asctime)s (%(hostname)s): %(levelname)s - %(message)s",
+        "format": f"%(asctime)s (%(hostname)s:%(zone)s): %(levelname)s - %(message)s",
         "date_format": None,
         "style": "%"
       },

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -533,7 +533,13 @@ class LazySettings(LazyObject):
     return self._wrapped.__enter__()
 
   def __exit__(self, exc_type=None, exc_value=None, traceback=None):
-    return self._wrapped.__exit__(exc_type, exc_value, traceback)
+    return_value = self._wrapped.__exit__(exc_type, exc_value, traceback)
+
+    # Incase the logger was messed with in the context, reset it.
+    from terra.core.signals import post_settings_context
+    post_settings_context.send(sender=self)
+
+    return return_value
 
 
 class ObjectDict(dict):

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -258,7 +258,7 @@ global_templates = [
     {
       "logging": {
         "level": "ERROR",
-        "format": f"%(asctime)s (%(hostname)s:%(zone)s): %(levelname)s - %(message)s",
+        "format": f"%(asctime)s (%(hostname)s:%(zone)s): %(levelname)s - %(filename)s - %(message)s",
         "date_format": None,
         "style": "%"
       },

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -428,6 +428,17 @@ class LazySettings(LazyObject):
       self.configure(json.load(fid))
     self._wrapped.config_file = os.environ.get(ENVIRONMENT_VARIABLE)
 
+  def __getstate__(self):
+    if self._wrapped is None:
+      self._setup()
+    return {'_wrapped': self._wrapped}
+
+  def __setstate__(self, state):
+    self._wrapped = state['_wrapped']
+
+    from terra.core.signals import post_settings_configured
+    post_settings_configured.send(sender=self)
+
   def __repr__(self):
     # Hardcode the class name as otherwise it yields 'Settings'.
     if self._wrapped is None:

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -263,13 +263,15 @@ global_templates = [
         "style": "%"
       },
       "executor": {
-        "type": "ThreadPoolExecutor"
+        "type": "ThreadPoolExecutor",
+        'volume_map': []
       },
       "compute": {
-        "arch": "terra.compute.dummy"
+        "arch": "terra.compute.dummy",
+        'volume_map': []
       },
       'terra': {
-        'zone': 'controller',
+        'zone': 'controller'
       },
       'status_file': status_file,
       'processing_dir': processing_dir,

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -436,8 +436,11 @@ class LazySettings(LazyObject):
   def __setstate__(self, state):
     self._wrapped = state['_wrapped']
 
-    from terra.core.signals import post_settings_configured
-    post_settings_configured.send(sender=self)
+    # This should NOT be done on a pre instance basis, this if only for
+    # the global terra.settings. So maybe this should be done in context
+    # manager??
+    # from terra.core.signals import post_settings_configured
+    # post_settings_configured.send(sender=self)
 
   def __repr__(self):
     # Hardcode the class name as otherwise it yields 'Settings'.

--- a/terra/core/signals.py
+++ b/terra/core/signals.py
@@ -353,6 +353,8 @@ element in the settings (which is done automatically), or in rare cases after a
 manual call to :func:`terra.core.settings.LazySettings.configure`.
 '''
 
+post_settings_context = Signal()
+
 from terra.logger import getLogger  # noqa
 logger = getLogger(__name__)
 # Must be after post_settings_configured to prevent circular import errors.

--- a/terra/core/signals.py
+++ b/terra/core/signals.py
@@ -37,6 +37,7 @@ See https://docs.djangoproject.com/en/2.2/topics/signals/ for more info
 # ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 # POSSIBILITY OF SUCH DAMAGE.
 
+import os
 import threading
 import weakref
 
@@ -197,9 +198,16 @@ class Signal:
     -------
     list
         Return a list of tuple pairs [(receiver, response), ... ].
+
+    Environment Variables
+    ---------------------
+    TERRA_UNITTEST
+        Setting this to ``1`` will disable send. This is used during
+        unittesting to prevent unexpected behavior
     """
     if not self.receivers or \
-       self.sender_receivers_cache.get(sender) is NO_RECEIVERS:
+       self.sender_receivers_cache.get(sender) is NO_RECEIVERS or \
+       os.environ.get('TERRA_UNITTEST') == "1":
       return []
 
     return [
@@ -228,9 +236,16 @@ class Signal:
         Return a list of tuple pairs [(receiver, response), ... ].
         If any receiver raises an error (specifically any subclass of
         Exception), return the error instance as the result for that receiver.
+
+    Environment Variables
+    ---------------------
+    TERRA_UNITTEST
+        Setting this to ``1`` will disable send. This is used during
+        unittesting to prevent unexpected behavior
     """
     if not self.receivers or \
-       self.sender_receivers_cache.get(sender) is NO_RECEIVERS:
+       self.sender_receivers_cache.get(sender) is NO_RECEIVERS or \
+       os.environ.get('TERRA_UNITTEST') == "1":
       return []
 
     # Call each receiver with whatever arguments it can accept.
@@ -342,7 +357,8 @@ def receiver(signal, **kwargs):
   return _decorator
 
 
-__all__ = ['Signal', 'receiver', 'post_settings_configured']
+__all__ = ['Signal', 'receiver', 'post_settings_configured',
+           'post_settings_context', 'logger_configure', 'logger_reconfigure']
 
 # a signal for settings done being loaded
 post_settings_configured = Signal()
@@ -354,6 +370,21 @@ manual call to :func:`terra.core.settings.LazySettings.configure`.
 '''
 
 post_settings_context = Signal()
+'''Signal:
+Sent after scope __exit__ from a settings context (i.e., with statement).
+'''
+
+logger_configure = Signal()
+'''Signal:
+Sent to the executor after the logger has been configured. This will happen
+after the post_settings_configured signal.
+'''
+
+logger_reconfigure = Signal()
+'''Signal:
+Sent to the executor after the logger has been reconfigured. This will happen
+after the logger_configure signal.
+'''
 
 from terra.logger import getLogger  # noqa
 logger = getLogger(__name__)

--- a/terra/core/utils.py
+++ b/terra/core/utils.py
@@ -193,3 +193,9 @@ class ClassHandler(Handler):
 
   def __call__(self, *args, **kwargs):
     return self._connection(*args, **kwargs)
+
+import threading
+
+class ThreadedHandler(Handler):
+  def _connection(self):
+    return self._connect_backend()

--- a/terra/core/utils.py
+++ b/terra/core/utils.py
@@ -194,7 +194,6 @@ class ClassHandler(Handler):
   def __call__(self, *args, **kwargs):
     return self._connection(*args, **kwargs)
 
-import threading
 
 class ThreadedHandler(Handler):
   def _connection(self):

--- a/terra/executor/base.py
+++ b/terra/executor/base.py
@@ -1,0 +1,18 @@
+from concurrent.futures import Future, Executor
+
+from terra.logger import getLogger
+logger = getLogger(__name__)
+
+
+class BaseExecutor(Executor):
+  @staticmethod
+  def configure_logger(sender, **kwargs):
+    pass
+
+  @staticmethod
+  def reconfigure_logger(sender, **kwargs):
+    pass
+
+
+class BaseFuture(Future):
+  pass

--- a/terra/executor/celery/__init__.py
+++ b/terra/executor/celery/__init__.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import sys
 from os import environ as env
 
 from celery import Celery
@@ -10,7 +11,15 @@ logger = getLogger(__name__)
 
 __all__ = ['CeleryExecutor']
 
-app = Celery(env['TERRA_CELERY_MAIN_NAME'])
+
+main_name = env.get('TERRA_CELERY_MAIN_NAME', None)
+if main_name is None:
+  try:
+    main_name = sys.modules['__main__'].__spec__.name
+  except:
+    main_name = "main_name_unset_Set_TERRA_CELERY_MAIN_NAME"
+app = Celery(main_name)
+
 app.config_from_object(env['TERRA_CELERY_CONF'])
 
 # app.running = False

--- a/terra/executor/celery/__init__.py
+++ b/terra/executor/celery/__init__.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-
 import sys
 from os import environ as env
 
@@ -17,7 +15,7 @@ if main_name is None:
   try:
     main_name = sys.modules['__main__'].__spec__.name
   except:
-    main_name = "main_name_unset_Set_TERRA_CELERY_MAIN_NAME"
+    main_name = "main_name_unset__set_TERRA_CELERY_MAIN_NAME"
 app = Celery(main_name)
 
 app.config_from_object(env['TERRA_CELERY_CONF'])
@@ -33,6 +31,3 @@ app.config_from_object(env['TERRA_CELERY_CONF'])
 
 # Running on windows.
 # https://stackoverflow.com/questions/37255548/how-to-run-celery-on-windows
-
-if __name__ == '__main__':  # pragma: no cover
-  app.start()

--- a/terra/executor/celery/__init__.py
+++ b/terra/executor/celery/__init__.py
@@ -13,6 +13,12 @@ __all__ = ['CeleryExecutor']
 app = Celery(env['TERRA_CELERY_MAIN_NAME'])
 app.config_from_object(env['TERRA_CELERY_CONF'])
 
+# app.running = False
+# from celery.signals import worker_process_init
+# @worker_process_init.connect
+# def set_running(*args, **kwargs):
+#     app.running = True
+
 # import traceback
 # traceback.print_stack()
 

--- a/terra/executor/celery/__init__.py
+++ b/terra/executor/celery/__init__.py
@@ -1,6 +1,7 @@
 import sys
 from os import environ as env
 
+from celery.signals import worker_process_init
 from celery import Celery
 
 from .executor import CeleryExecutor
@@ -14,20 +15,18 @@ main_name = env.get('TERRA_CELERY_MAIN_NAME', None)
 if main_name is None:
   try:
     main_name = sys.modules['__main__'].__spec__.name
-  except:
+  except AttributeError:
+   # if __spec__ is None, then __main__ is a builtin
     main_name = "main_name_unset__set_TERRA_CELERY_MAIN_NAME"
 app = Celery(main_name)
 
 app.config_from_object(env['TERRA_CELERY_CONF'])
 
-# app.running = False
-# from celery.signals import worker_process_init
-# @worker_process_init.connect
-# def set_running(*args, **kwargs):
-#     app.running = True
 
-# import traceback
-# traceback.print_stack()
+@worker_process_init.connect
+def start_worker_child(*args, **kwargs):
+  from terra import settings
+  settings.terra.zone = 'task'
 
 # Running on windows.
 # https://stackoverflow.com/questions/37255548/how-to-run-celery-on-windows

--- a/terra/executor/celery/__main__.py
+++ b/terra/executor/celery/__main__.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python
+
+from os import environ as env
+from . import app
+
+def main():
+  app.start()
+
+if __name__ == '__main__':  # pragma: no cover
+  main()

--- a/terra/executor/celery/__main__.py
+++ b/terra/executor/celery/__main__.py
@@ -3,8 +3,22 @@
 from os import environ as env
 from . import app
 
+# Terra
+from terra import settings
+
+
 def main():
+  if env.get('TERRA_SETTINGS_FILE', '') == '':
+    settings.configure(
+      {
+        'executor': {'type': 'CeleryExecutor'},
+        'terra': {'zone': 'task_controller'},
+        'logging': {'level': 'NOTSET'}
+      }
+    )
+
   app.start()
+
 
 if __name__ == '__main__':  # pragma: no cover
   main()

--- a/terra/executor/celery/celeryconfig.py
+++ b/terra/executor/celery/celeryconfig.py
@@ -21,7 +21,9 @@ broker_url = f'redis://:{password}@{env["TERRA_REDIS_HOSTNAME"]}:' \
 result_backend = broker_url
 
 task_serializer = 'pickle'
+result_serializer = 'pickle'
 accept_content = ['json', 'pickle']
+result_accept_content = ['json', 'pickle']
 result_expires = 3600
 
 # App needs to define include

--- a/terra/executor/celery/celeryconfig.py
+++ b/terra/executor/celery/celeryconfig.py
@@ -31,3 +31,4 @@ celery_include = env.get('TERRA_CELERY_INCLUDE', None)
 if celery_include:
   import ast
   include = ast.literal_eval(celery_include)
+  include += type(include)(['terra.tests.demo.tasks'])

--- a/terra/executor/celery/executor.py
+++ b/terra/executor/celery/executor.py
@@ -191,7 +191,7 @@ class CeleryExecutor(Executor):
   def shutdown(self, wait=True):
     with self._shutdown_lock:
       self._shutdown = True
-      for fut in self._futures:
+      for fut in tuple(self._futures):
         fut.cancel()
 
     if wait:

--- a/terra/executor/celery/executor.py
+++ b/terra/executor/celery/executor.py
@@ -231,21 +231,4 @@ class CeleryExecutor(Executor):
 
     volume_map = compute.get_volume_map(config, service_clone)
 
-    # # In the case of docker, the config has /tmp_settings in there, this
-    # # should be removed, as it is not in the celery worker. I don't think it
-    # # would cause any problems, but it's inaccurate.
-    # volume_map = [v for v in volume_map if v[1] != '/tmp_settings']
-
     return volume_map
-
-    # optional_args = {}
-    # optional_args['justfile'] = justfile
-
-    # args = ["--wrap", "Just-docker-compose"] + \
-    #     sum([['-f', cf] for cf in compose_files], []) + \
-    #     ['config']
-
-    # pid = just(*args, stdout=PIPE,
-    #            **optional_args,
-    #            env=service_info.env)
-    # return pid.communicate()[0]

--- a/terra/executor/dummy.py
+++ b/terra/executor/dummy.py
@@ -1,12 +1,12 @@
-from concurrent.futures import Future, Executor
 from threading import Lock
 
+from terra.executor.base import BaseFuture, BaseExecutor
 from terra import settings
 from terra.logger import getLogger
 logger = getLogger(__name__)
 
 
-class DummyExecutor(Executor):
+class DummyExecutor(BaseExecutor):
   """
   Executor that does nothing, just logs what would happen.
 
@@ -27,7 +27,7 @@ class DummyExecutor(Executor):
       original_zone = settings.terra.zone
       # Fake the zone for the log messages
       settings.terra.zone = 'task'
-      f = Future()
+      f = BaseFuture()
       logger.info(f'Run function: {fn}')
       logger.info(f'With args: {args}')
       logger.info(f'With kwargs: {kwargs}')

--- a/terra/executor/dummy.py
+++ b/terra/executor/dummy.py
@@ -1,6 +1,7 @@
 from concurrent.futures import Future, Executor
 from threading import Lock
 
+from terra import settings
 from terra.logger import getLogger
 logger = getLogger(__name__)
 
@@ -21,11 +22,15 @@ class DummyExecutor(Executor):
       if self._shutdown:
         raise RuntimeError('cannot schedule new futures after shutdown')
 
+      original_zone = settings.terra.zone
+      # Fake the zone for the log messages
+      settings.terra.zone = 'task'
       f = Future()
       logger.info(f'Run function: {fn}')
       logger.info(f'With args: {args}')
       logger.info(f'With kwargs: {kwargs}')
       f.set_result(None)
+      settings.terra.zone = original_zone
       return f
 
   def shutdown(self, wait=True):

--- a/terra/executor/dummy.py
+++ b/terra/executor/dummy.py
@@ -21,16 +21,12 @@ class DummyExecutor(Executor):
       if self._shutdown:
         raise RuntimeError('cannot schedule new futures after shutdown')
 
-      from terra import settings
-
-      with settings:
-        settings.terra.zone = 'task'
-        f = Future()
-        logger.info(f'Run function: {fn}')
-        logger.info(f'With args: {args}')
-        logger.info(f'With kwargs: {kwargs}')
-        f.set_result(None)
-        return f
+      f = Future()
+      logger.info(f'Run function: {fn}')
+      logger.info(f'With args: {args}')
+      logger.info(f'With kwargs: {kwargs}')
+      f.set_result(None)
+      return f
 
   def shutdown(self, wait=True):
     with self._shutdown_lock:

--- a/terra/executor/dummy.py
+++ b/terra/executor/dummy.py
@@ -7,7 +7,7 @@ logger = getLogger(__name__)
 
 class DummyExecutor(Executor):
   """
-  Executor that does the nothin, just logs what would happen.
+  Executor that does nothing, just logs what would happen.
   """
 
   def __init__(self, *arg, **kwargs):
@@ -21,12 +21,16 @@ class DummyExecutor(Executor):
       if self._shutdown:
         raise RuntimeError('cannot schedule new futures after shutdown')
 
-      f = Future()
-      logger.info(f'Run function: {fn}')
-      logger.info(f'With args: {args}')
-      logger.info(f'With kwargs: {kwargs}')
-      f.set_result(None)
-      return f
+      from terra import settings
+
+      with settings:
+        settings.terra.zone = 'task'
+        f = Future()
+        logger.info(f'Run function: {fn}')
+        logger.info(f'With args: {args}')
+        logger.info(f'With kwargs: {kwargs}')
+        f.set_result(None)
+        return f
 
   def shutdown(self, wait=True):
     with self._shutdown_lock:

--- a/terra/executor/dummy.py
+++ b/terra/executor/dummy.py
@@ -9,6 +9,8 @@ logger = getLogger(__name__)
 class DummyExecutor(Executor):
   """
   Executor that does nothing, just logs what would happen.
+
+  Note: Don't base new executors off of this example
   """
 
   def __init__(self, *arg, **kwargs):

--- a/terra/executor/process.py
+++ b/terra/executor/process.py
@@ -1,0 +1,9 @@
+import concurrent.futures
+import terra.executor.base
+
+__all__ = ['ProcessPoolExecutor']
+
+
+class ProcessPoolExecutor(concurrent.futures.ProcessPoolExecutor,
+                          terra.executor.base.BaseExecutor):
+  pass

--- a/terra/executor/sync.py
+++ b/terra/executor/sync.py
@@ -1,9 +1,10 @@
-from concurrent.futures import Future, Executor
 from threading import Lock
+
+from terra.executor.base import BaseExecutor, BaseFuture
 
 
 # No need for a global shutdown lock here, not multi-threaded/process
-class SyncExecutor(Executor):
+class SyncExecutor(BaseExecutor):
   """
   Executor that does the job synchronously.
 
@@ -25,7 +26,7 @@ class SyncExecutor(Executor):
       if self._shutdown:
         raise RuntimeError('cannot schedule new futures after shutdown')
 
-      f = Future()
+      f = BaseFuture()
       try:
         result = fn(*args, **kwargs)
       except BaseException as e:

--- a/terra/executor/sync.py
+++ b/terra/executor/sync.py
@@ -3,8 +3,6 @@ from threading import Lock
 
 
 # No need for a global shutdown lock here, not multi-threaded/process
-
-
 class SyncExecutor(Executor):
   """
   Executor that does the job synchronously.
@@ -27,15 +25,19 @@ class SyncExecutor(Executor):
       if self._shutdown:
         raise RuntimeError('cannot schedule new futures after shutdown')
 
-      f = Future()
-      try:
-        result = fn(*args, **kwargs)
-      except BaseException as e:
-        f.set_exception(e)
-      else:
-        f.set_result(result)
+      from terra import settings
+      with settings:
+        settings.terra.zone = 'task'
 
-      return f
+        f = Future()
+        try:
+          result = fn(*args, **kwargs)
+        except BaseException as e:
+          f.set_exception(e)
+        else:
+          f.set_result(result)
+
+        return f
 
   def shutdown(self, wait=True):
     with self._shutdown_lock:

--- a/terra/executor/sync.py
+++ b/terra/executor/sync.py
@@ -25,19 +25,15 @@ class SyncExecutor(Executor):
       if self._shutdown:
         raise RuntimeError('cannot schedule new futures after shutdown')
 
-      from terra import settings
-      with settings:
-        settings.terra.zone = 'task'
+      f = Future()
+      try:
+        result = fn(*args, **kwargs)
+      except BaseException as e:
+        f.set_exception(e)
+      else:
+        f.set_result(result)
 
-        f = Future()
-        try:
-          result = fn(*args, **kwargs)
-        except BaseException as e:
-          f.set_exception(e)
-        else:
-          f.set_result(result)
-
-        return f
+      return f
 
   def shutdown(self, wait=True):
     with self._shutdown_lock:

--- a/terra/executor/thread.py
+++ b/terra/executor/thread.py
@@ -1,0 +1,9 @@
+import concurrent.futures
+import terra.executor.base
+
+__all__ = ['ThreadPoolExecutor']
+
+
+class ThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor,
+                         terra.executor.base.BaseExecutor):
+  pass

--- a/terra/executor/utils.py
+++ b/terra/executor/utils.py
@@ -60,9 +60,11 @@ class ExecutorHandler(ClassHandler):
     log_file = os.path.join(settings.processing_dir,
                             terra.logger._logs.default_log_prefix)
 
-    if not os.path.samefile(log_file, self._log_file.name):
+    # if not os.path.samefile(log_file, self._log_file.name):
+    if log_file != self._log_file.name:
       os.makedirs(settings.processing_dir, exist_ok=True)
-      log_file = open(log_file, 'a')
+      self._log_file.close()
+      self._log_file = open(log_file, 'a')
 
   def configure_logger(self):
     # ThreadPoolExecutor will work just fine with a normal StreamHandler

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -69,6 +69,8 @@ import warnings
 from datetime import datetime, timezone
 
 from terra.core.exceptions import ImproperlyConfigured
+# Do not import terra.settings or terra.signals here, or any module that
+# imports them
 
 from logging import (
   CRITICAL, ERROR, INFO, FATAL, WARN, WARNING, NOTSET,

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -321,7 +321,8 @@ class _SetupTerraLogger():
 
     # Remove the temporary file now that you are done with it
     self.tmp_file.close()
-    os.unlink(self.tmp_file.name)
+    if os.path.exists(self.tmp_file.name):
+      os.unlink(self.tmp_file.name)
     self.tmp_file = None
 
     self._configured = True

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -127,7 +127,8 @@ class _SetupTerraLogger():
   after :data:`terra.settings` is configured
   '''
   default_formatter = logging.Formatter('%(asctime)s (%(hostname)s:%(zone)s) :'
-                                        ' %(levelname)s - %(message)s')
+                                        ' %(levelname)s - %(filename)s -'
+                                        ' %(message)s')
   default_stderr_handler_level = logging.WARNING
   default_tmp_prefix = "terra_initial_tmp_"
   default_log_prefix = "terra_log"
@@ -178,6 +179,12 @@ class _SetupTerraLogger():
 
     # Enable warnings to default
     warnings.simplefilter('default')
+    warnings.filterwarnings("ignore",
+        category=DeprecationWarning, module='yaml',
+        message="ABCs from 'collections' instead of from 'collections.abc'")
+    warnings.filterwarnings("ignore",
+        category=DeprecationWarning, module='osgeo',
+        message="the imp module is deprecated")
 
   def setup_logging_exception_hook(self):
     '''

--- a/terra/task.py
+++ b/terra/task.py
@@ -15,10 +15,12 @@ logger = getLogger(__name__)
 
 __all__ = ['TerraTask', 'shared_task']
 
+
 def shared_task(*args, **kwargs):
-  kwargs['bind'] = True
-  kwargs['base'] = TerraTask
+  kwargs['bind'] = kwargs.pop('bind', True)
+  kwargs['base'] = kwargs.pop('base', TerraTask)
   return original_shared_task(*args, **kwargs)
+
 
 class TerraTask(Task):
   settings = None
@@ -76,6 +78,9 @@ class TerraTask(Task):
         terra.logger._logs.reconfigure_logger()
         return_value = self.run(*args, **kwargs)
     else:
+      original_zone = settings.terra.zone
+      settings.terra.zone = 'task'
       return_value = self.run(*args, **kwargs)
+      settings.terra.zone = original_zone
     self.settings = None
     return return_value

--- a/terra/task.py
+++ b/terra/task.py
@@ -72,6 +72,7 @@ class TerraTask(Task):
           logger.warning('Using temporary directory: '
                          f'"{settings.processing_dir}" for the processing dir')
         logger.critical(settings)
+        settings.terra.zone = 'task'
         terra.logger._logs.reconfigure_logger()
         return_value = self.run(*args, **kwargs)
     else:

--- a/terra/task.py
+++ b/terra/task.py
@@ -1,15 +1,13 @@
-import json
-from os import environ as env
 import os
 from tempfile import gettempdir
 
-from celery import Task, shared_task as original_shared_task
+from celery import shared_task as original_shared_task
+from celery.app.task import Task
 
 from vsi.tools.python import args_to_kwargs, ARGS, KWARGS
 
 from terra import settings
 from terra.core.settings import TerraJSONEncoder
-from terra.executor import Executor
 import terra.logger
 import terra.compute.utils
 from terra.logger import getLogger
@@ -18,6 +16,8 @@ logger = getLogger(__name__)
 __all__ = ['TerraTask', 'shared_task']
 
 
+# Take the shared task decorator, and add some Terra defaults, so you don't
+# need to specify them EVERY task
 def shared_task(*args, **kwargs):
   kwargs['bind'] = kwargs.pop('bind', True)
   kwargs['base'] = kwargs.pop('base', TerraTask)
@@ -25,19 +25,6 @@ def shared_task(*args, **kwargs):
 
 
 class TerraTask(Task):
-  settings = None
-  # @staticmethod
-  # def _patch_settings(args, kwargs):
-  #   if 'TERRA_EXECUTOR_SETTINGS_FILE' in env:
-  #     # TODO: Cache loads for efficiency?
-  #     settings = json.load(env['TERRA_EXECUTOR_SETTINGS_FILE'])
-
-  #     # If args is not empty, the first arg was settings
-  #     if args:
-  #       args[0] = settings
-  #     else:
-  #       kwargs['settings'] = settings
-
   def _get_volume_mappings(self):
     executor_volume_map = self.request.settings['executor']['volume_map']
 
@@ -52,7 +39,7 @@ class TerraTask(Task):
       reverse_compute_volume_map.reverse()
 
       reverse_executor_volume_map = [[x[1], x[0]]
-                                    for x in executor_volume_map]
+                                     for x in executor_volume_map]
       reverse_executor_volume_map.reverse()
 
     else:
@@ -80,17 +67,16 @@ class TerraTask(Task):
             payload, executor_volume_map)
     return payload
 
+  # Don't need to apply translations for apply, it runs locally
+  # def apply(self, *args, **kwargs):
+
+  # apply_async needs to smuggle a copy of the settings to the task
   def apply_async(self, args=None, kwargs=None, task_id=None,
                   *args2, **kwargs2):
     current_settings = TerraJSONEncoder.serializableSettings(settings)
     return super().apply_async(args=args, kwargs=kwargs,
                                headers={'settings': current_settings},
                                task_id=task_id, *args2, **kwargs2)
-
-  # Don't need to apply translations for apply, it runs locally
-  # def apply(self, *args, **kwargs):
-  #   # TerraTask._patch_settings(args, kwargs)
-  #   return super().apply(*args, settings={'X': 15}, **kwargs)
 
   def __call__(self, *args, **kwargs):
     # this is only set when apply_async was called.
@@ -99,14 +85,24 @@ class TerraTask(Task):
         # Cover a potential (unlikely) corner case where setting might not be
         # configured yet
         settings.configure({'processing_dir': gettempdir()})
+
+      # Create a settings context, so I can replace it with the task's settings
       with settings:
+        # Calculate the exector's mapped version of the runner's settings
         compute_volume_map, reverse_compute_volume_map, \
-        executor_volume_map, reverse_executor_volume_map = \
+            executor_volume_map, reverse_executor_volume_map = \
             self._get_volume_mappings()
 
+        # Load the executor version of the runner's settings
         settings._wrapped.clear()
-        settings._wrapped.update(self.translate_paths(self.request.settings,
-            reverse_compute_volume_map, executor_volume_map))
+        settings._wrapped.update(self.translate_paths(
+            self.request.settings,
+            reverse_compute_volume_map,
+            executor_volume_map))
+        # This is needed here because I just loaded settings from a runner!
+        settings.terra.zone = 'task'
+
+        # Just in case processing dir doesn't exists
         if not os.path.exists(settings.processing_dir):
           logger.critical(f'Dir "{settings.processing_dir}" is not accessible '
                           'by the executor, please make sure the worker has '
@@ -114,25 +110,34 @@ class TerraTask(Task):
           settings.processing_dir = gettempdir()
           logger.warning('Using temporary directory: '
                          f'"{settings.processing_dir}" for the processing dir')
-        settings.terra.zone = 'task'
+
+        # Calculate the exector's mapped version of the arguments
         kwargs = args_to_kwargs(self.run, args, kwargs)
         args_only = kwargs.pop(ARGS, ())
         kwargs.update(kwargs.pop(KWARGS, ()))
         kwargs = self.translate_paths(kwargs,
-            reverse_compute_volume_map, executor_volume_map)
-        terra.logger._logs.reconfigure_logger()
+                                      reverse_compute_volume_map,
+                                      executor_volume_map)
+        # Set up logger to talk to master controller
+        terra.logger._logs.reconfigure_logger(pre_run_task=True)
         return_value = self.run(*args_only, **kwargs)
 
+        # Calculate the runner mapped version of the executor's return value
         return_value = self.translate_paths(return_value,
-            reverse_executor_volume_map, compute_volume_map)
+                                            reverse_executor_volume_map,
+                                            compute_volume_map)
     else:
-      # Must by just apply (synchronous), or a normal call with no volumes
-      # mapping
+      # Must call (synchronous) apply or python __call__ with no volume
+      # mappings
       original_zone = settings.terra.zone
       settings.terra.zone = 'task'
       try:
         return_value = self.run(*args, **kwargs)
       finally:
         settings.terra.zone = original_zone
-    self.settings = None
     return return_value
+
+  # # from https://stackoverflow.com/a/45333231/1771778
+  # def on_failure(self, exc, task_id, args, kwargs, einfo):
+  #   logger.exception('Celery task failure!!!', exc_info=exc)
+  #   return super().on_failure(exc, task_id, args, kwargs, einfo)

--- a/terra/task.py
+++ b/terra/task.py
@@ -118,7 +118,9 @@ class TerraTask(Task):
     else:
       original_zone = settings.terra.zone
       settings.terra.zone = 'task'
-      return_value = self.run(*args, **kwargs)
-      settings.terra.zone = original_zone
+      try:
+        return_value = self.run(*args, **kwargs)
+      finally:
+        settings.terra.zone = original_zone
     self.settings = None
     return return_value

--- a/terra/task.py
+++ b/terra/task.py
@@ -1,6 +1,13 @@
 from os import environ as env
+from tempfile import gettempdir
 
 from celery import Task, shared_task as original_shared_task
+
+from terra import settings
+from terra.core.settings import TerraJSONEncoder
+from terra.executor import Executor
+import terra.logger
+import terra.compute.utils
 
 __all__ = ['TerraTask', 'shared_task']
 
@@ -10,24 +17,56 @@ def shared_task(*args, **kwargs):
   return original_shared_task(*args, **kwargs)
 
 class TerraTask(Task):
-  @staticmethod
-  def _patch_settings(args, kwargs):
-    if 'TERRA_EXECUTOR_SETTINGS_FILE' in env:
-      # TODO: Cache loads for efficiency?
-      settings = json.load(env['TERRA_EXECUTOR_SETTINGS_FILE'])
+  settings = None
+  # @staticmethod
+  # def _patch_settings(args, kwargs):
+  #   if 'TERRA_EXECUTOR_SETTINGS_FILE' in env:
+  #     # TODO: Cache loads for efficiency?
+  #     settings = json.load(env['TERRA_EXECUTOR_SETTINGS_FILE'])
 
-      # If args is not empty, the first arg was settings
-      if args:
-        args[0] = settings
-      else:
-        kwargs['settings'] = settings
+  #     # If args is not empty, the first arg was settings
+  #     if args:
+  #       args[0] = settings
+  #     else:
+  #       kwargs['settings'] = settings
+
+  def serialize_settings(self):
+    # If there is a non-empty mapping, then create a custom executor settings
+    executor_volume_map = self.request.settings.pop('executor_volume_map',
+                                                    None)
+    if executor_volume_map:
+      return terra.compute.utils.translate_settings_paths(
+          TerraJSONEncoder.serializableSettings(self.request.settings),
+          executor_volume_map)
+    return self.request.settings
 
   def apply_async(self, args=None, kwargs=None, task_id=None, user=None,
                   *args2, **kwargs2):
-    TerraTask._patch_settings(args, kwargs)
     return super().apply_async(args=args, kwargs=kwargs,
-                               task_id=task_id, *args2, **kwargs2)
+                               task_id=task_id, *args2, headers={'settings': TerraJSONEncoder.serializableSettings(settings)},
+                               **kwargs2)
 
-  def apply(self, *args, **kwargs):
-    TerraTask._patch_settings(args, kwargs)
-    return super().apply(*args, **kwargs)
+  # def apply(self, *args, **kwargs):
+  #   # TerraTask._patch_settings(args, kwargs)
+  #   return super().apply(*args, settings={'X': 15}, **kwargs)
+
+  def __call__(self, *args, **kwargs):
+    print('111')
+    if getattr(self.request, 'settings', None):
+      print('222')
+      if not settings.configured:
+        print('333')
+        settings.configure({'processing_dir': gettempdir()})
+      with settings:
+        print('444')
+        print(settings)
+        settings._wrapped.clear()
+        settings._wrapped.update(self.serialize_settings())
+        print(settings)
+        settings.processing_dir=gettempdir()
+        terra.logger._logs.reconfigure_logger()
+        return_value = self.run(*args, **kwargs)
+    else:
+      return_value = self.run(*args, **kwargs)
+    self.settings = None
+    return return_value

--- a/terra/task.py
+++ b/terra/task.py
@@ -1,0 +1,33 @@
+from os import environ as env
+
+from celery import Task, shared_task as original_shared_task
+
+__all__ = ['TerraTask', 'shared_task']
+
+def shared_task(*args, **kwargs):
+  kwargs['bind'] = True
+  kwargs['base'] = TerraTask
+  return original_shared_task(*args, **kwargs)
+
+class TerraTask(Task):
+  @staticmethod
+  def _patch_settings(args, kwargs):
+    if 'TERRA_EXECUTOR_SETTINGS_FILE' in env:
+      # TODO: Cache loads for efficiency?
+      settings = json.load(env['TERRA_EXECUTOR_SETTINGS_FILE'])
+
+      # If args is not empty, the first arg was settings
+      if args:
+        args[0] = settings
+      else:
+        kwargs['settings'] = settings
+
+  def apply_async(self, args=None, kwargs=None, task_id=None, user=None,
+                  *args2, **kwargs2):
+    TerraTask._patch_settings(args, kwargs)
+    return super().apply_async(args=args, kwargs=kwargs,
+                               task_id=task_id, *args2, **kwargs2)
+
+  def apply(self, *args, **kwargs):
+    TerraTask._patch_settings(args, kwargs)
+    return super().apply(*args, **kwargs)

--- a/terra/tests/__init__.py
+++ b/terra/tests/__init__.py
@@ -1,12 +1,17 @@
 import os
+import warnings
+
+
+original_environ = os.environ.copy()
 
 
 # Use this as a package level setup
 def load_tests(loader, standard_tests, pattern):
   if os.environ.get('TERRA_UNITTEST', None) != "1":
-    print('WARNING: Running terra tests without setting TERRA_UNITTEST will '
-          'result in side effects such as extraneouse log files being '
-          'generated')
+    warnings.warn(
+        'WARNING: Running terra tests without setting TERRA_UNITTEST will '
+        'result in side effects such as extraneouse log files being '
+        'generated')
 
   this_dir = os.path.dirname(__file__)
   package_tests = loader.discover(start_dir=this_dir, pattern=pattern)

--- a/terra/tests/demo/__main__.py
+++ b/terra/tests/demo/__main__.py
@@ -1,0 +1,103 @@
+'''
+Demo app that tests if a terra config is working
+
+*** WARNING *** This will spin up real computers and workers, if you are
+configured to do so. May result in a small amount of billing.
+'''
+
+from os import environ as env
+import tempfile
+import os
+import json
+import pydoc
+
+from terra import settings
+from terra.core.settings import ENVIRONMENT_VARIABLE, settings_property
+from terra.core.exceptions import ImproperlyConfigured
+from terra.utils.cli import FullPaths, ArgumentParser
+
+
+@settings_property
+def singularity_unset(self):
+  raise ImproperlyConfigured('You must to set --compose and --service for '
+                             'singularity')
+
+
+def demo_templates():
+  docker = {
+    "demo": {"compose": os.path.join(env['TERRA_TERRA_DIR'],
+                                     'docker-compose-main.yml'),
+             "service": "terra-demo"}
+  }
+
+  singularity = {
+    "demo": {"compose": singularity_unset,
+             "service": singularity_unset}
+  }
+
+  templates = [
+    ({"compute": {"arch": "docker"}}, docker),
+    ({"compute": {"arch": "terra.compute.docker"}}, docker),
+    ({"compute": {"arch": "singularity"}}, singularity),
+    ({"compute": {"arch": "terra.compute.singularity"}}, singularity)
+  ]
+  return templates
+
+
+def get_parser():
+  parser = ArgumentParser(description="View Angle Runner")
+  aa = parser.add_argument
+  aa('--loglevel', type=str, help="Log level", default=None)
+  aa('--compose', type=str, default=None,
+     help="Compose filename (for docker/singularity)")
+  aa('--service', type=str, default=None,
+     help="Service name (for docker/singularity)")
+  aa('settings', type=str, help="JSON settings file",
+     default=os.environ.get(ENVIRONMENT_VARIABLE), action=FullPaths)
+  return parser
+
+
+def main(processing_dir, args=None):
+  args = get_parser().parse_args(args)
+
+  # Load settings
+  with open(args.settings, 'r') as fid:
+    settings_json = json.load(fid)
+
+  # Patch settings for demo
+  settings_json['processing_dir'] = processing_dir
+  settings_json['demo'] = {}
+
+  if args.compose:
+    settings_json['demo']['compose'] = args.compose
+  if args.service:
+    settings_json['demo']['service'] = args.service
+  if args.loglevel:
+    try:
+      settings_json['logging']['level'] = args.loglevel
+    except KeyError:
+      settings_json['logging'] = {'level': args.loglevel}
+
+  # Configure settings
+  settings.add_templates(demo_templates())
+  settings.configure(settings_json)
+
+  # import pprint
+  # pprint.pprint(settings)
+
+  # Run workflow
+  from .workflows import DemoWorkflow
+  DemoWorkflow().demonate()
+
+
+if __name__ == '__main__':
+  processing_dir = tempfile.TemporaryDirectory()
+  try:
+    main(processing_dir.name)
+    with open(os.path.join(processing_dir.name, 'terra_log'), 'r') as fid:
+      print('-------------------')
+      print('Paging log messages')
+      print('-------------------')
+      pydoc.pager(fid.read())
+  finally:
+    processing_dir.cleanup()

--- a/terra/tests/demo/runners/demo1.py
+++ b/terra/tests/demo/runners/demo1.py
@@ -1,0 +1,21 @@
+'''
+Demo app that tests if a terra config is working
+
+*** WARNING *** This will spin up real computers and workers, if you are
+configured to do so. May result in a small amount of billing.
+'''
+
+from terra.utils.cli import ArgumentParser
+from terra import settings
+from terra.logger import getLogger
+logger = getLogger(__name__)
+
+
+def main(args=None):
+  settings.terra.zone
+  logger.critical('Demo 1')
+
+
+if __name__ == '__main__':
+  ArgumentParser().parse_args()
+  main()

--- a/terra/tests/demo/runners/demo2.py
+++ b/terra/tests/demo/runners/demo2.py
@@ -1,0 +1,37 @@
+'''
+Demo app that tests if a terra config is working
+
+*** WARNING *** This will spin up real computers and workers, if you are
+configured to do so. May result in a small amount of billing.
+'''
+
+import concurrent.futures
+
+from terra.tests.demo.tasks import demo2
+from terra.utils.cli import ArgumentParser
+from terra.executor import Executor
+from terra import settings
+from terra.logger import getLogger
+logger = getLogger(__name__)
+
+
+def main(args=None):
+  settings.terra.zone
+  logger.critical('Demo 2 Starting')
+
+  futures = {}
+
+  with Executor(max_workers=4) as executor:
+    for x in range(1, 3):
+      for y in range(4, 6):
+        futures[executor.submit(demo2, x, y)] = (x, y)
+
+    for future in concurrent.futures.as_completed(futures):
+      logger.info(f'Completed: {settings.terra.zone} {futures[future]}')
+
+  logger.critical('Demo 2 Done')
+
+
+if __name__ == '__main__':
+  ArgumentParser().parse_args()
+  main()

--- a/terra/tests/demo/services.py
+++ b/terra/tests/demo/services.py
@@ -1,0 +1,73 @@
+from terra import settings
+from terra.compute.docker import (
+  Service as DockerService,
+  Compute as DockerCompute
+)
+from terra.compute.singularity import (
+  Service as SingularityService,
+  Compute as SingularityCompute
+)
+from terra.compute.virtualenv import (
+  Service as VirtualEnvService,
+  Compute as VirtualEnvCompute
+)
+from terra.compute.base import BaseService
+
+
+class Demo1(BaseService):
+  ''' Simple Demo Service '''
+  command = ['python', '-m', 'terra.tests.demo.runners.demo1']
+  CONTAINER_PROCESSING_DIR = "/opt/test"
+
+  def pre_run(self):
+    self.add_volume(settings.processing_dir,
+                    Demo1.CONTAINER_PROCESSING_DIR,
+                    'rw')
+    super().pre_run()
+
+
+@DockerCompute.register(Demo1)
+class Demo1_docker(DockerService, Demo1):
+  def __init__(self):
+    super().__init__()
+    self.compose_files = [settings.demo.compose]
+    self.compose_service_name = settings.demo.service
+
+
+@SingularityCompute.register(Demo1)
+class Demo1_singularity(SingularityService, Demo1):
+  def __init__(self):
+    super().__init__()
+    self.compose_files = [settings.demo.compose]
+    self.compose_service_name = settings.demo.service
+
+
+@VirtualEnvCompute.register(Demo1)
+class Demo1_virtualenv(VirtualEnvService, Demo1):
+  pass
+
+
+class Demo2(Demo1):
+  ''' Simple Demo Service '''
+  command = ['python', '-m', 'terra.tests.demo.runners.demo2']
+
+
+@DockerCompute.register(Demo2)
+class Demo2_docker(DockerService, Demo2):
+  def __init__(self):
+    super().__init__()
+    self.compose_files = [settings.demo.compose]
+    self.compose_service_name = settings.demo.service
+
+
+@SingularityCompute.register(Demo2)
+class Demo2_singularity(SingularityService, Demo2):
+  def __init__(self):
+    super().__init__()
+    self.compose_files = [settings.demo.compose]
+    self.compose_service_name = settings.demo.service
+
+
+@VirtualEnvCompute.register(Demo2)
+class Demo2_virtualenv(VirtualEnvService, Demo2):
+  pass

--- a/terra/tests/demo/tasks.py
+++ b/terra/tests/demo/tasks.py
@@ -1,0 +1,11 @@
+from terra.task import shared_task
+
+# Terra core
+from terra.logger import getLogger
+logger = getLogger(__name__)
+
+
+@shared_task
+def demo2(self, x, y):
+  logger.critical(f"Task: {x} {y}")
+  return x * y

--- a/terra/tests/demo/workflows.py
+++ b/terra/tests/demo/workflows.py
@@ -1,0 +1,12 @@
+from terra.compute import compute
+
+from terra.logger import getLogger
+logger = getLogger(__name__)
+
+
+class DemoWorkflow:
+  def demonate(self):
+    logger.critical('Starting demo workflow')
+    compute.run('terra.tests.demo.services.Demo1')
+    compute.run('terra.tests.demo.services.Demo2')
+    logger.critical('Ran demo workflow')

--- a/terra/tests/test_compute_base.py
+++ b/terra/tests/test_compute_base.py
@@ -2,32 +2,20 @@ import os
 from unittest import mock
 
 from terra import settings
-from terra.compute import base
-from .utils import TestCase
+from .utils import TestCase, TestSettingsConfiguredCase
 
 
-# Registration test
-class Foo:
-  class TestService(base.BaseService):
-    pass
-
-
-class TestService_base(Foo.TestService, base.BaseService):
-  pass
-
-
-class TestServiceBase(TestCase):
+class TestServiceBase(TestSettingsConfiguredCase):
   def setUp(self):
-    # I want to be able to use settings
-    self.patches.append(mock.patch.object(settings, '_wrapped', None))
+    from terra.compute import base
+    self.base = base
     super().setUp()
-    settings.configure({})
 
   # Simulate external env var
   @mock.patch.dict(os.environ, {'FOO': "BAR"})
   def test_env(self):
     # Test that a service inherits the environment correctly
-    service = base.BaseService()
+    service = self.base.BaseService()
     # App specific env var
     service.env['BAR'] = 'foo'
     # Make sure both show up
@@ -37,7 +25,7 @@ class TestServiceBase(TestCase):
     self.assertNotIn("BAR", os.environ)
 
   def test_add_volumes(self):
-    service = base.BaseService()
+    service = self.base.BaseService()
     # Add a volumes
     service.add_volume("/local", "/remote")
     # Make sure it's in the list
@@ -47,30 +35,39 @@ class TestServiceBase(TestCase):
   @mock.patch.object(settings, '_wrapped', None)
   def test_volumes_and_configuration_map(self):
     # Add a volumes
-    service = base.BaseService()
+    service = self.base.BaseService()
     service.add_volume("/local", "/remote")
 
     # Test configuration_map
     settings.configure({})
     # Make sure the volume is in the map
     self.assertEqual([("/local", "/remote")],
-                     base.BaseCompute().configuration_map(service))
+                     self.base.BaseCompute().configuration_map(service))
 
-  @mock.patch.dict(base.services, clear=True)
   def test_registry(self):
-    # Register a class class, just for fun
-    base.BaseCompute.register(Foo.TestService)(TestService_base)
+    with mock.patch.dict(self.base.services, clear=True):
+      # Registration test
+      class Foo:
+        class TestService(self.base.BaseService):
+          pass
 
-    self.assertIn(Foo.TestService.__module__ + '.Foo.TestService',
-                  base.services)
+      class TestService_base(Foo.TestService, self.base.BaseService):
+        pass
 
-    with self.assertRaises(base.AlreadyRegisteredException,
-                           msg='Compute command "car" does not have a service '
-                               'implementation "car_service"'):
-      base.BaseCompute.register(Foo.TestService)(lambda x: 1)
+      # Register a class class, just for fun
+      self.base.BaseCompute.register(Foo.TestService)(TestService_base)
+
+      self.assertIn(Foo.TestService.__module__ + '.'
+                    + Foo.TestService.__qualname__,
+                    self.base.services)
+
+      with self.assertRaises(self.base.AlreadyRegisteredException,
+                             msg='Compute command "car" does not have a '
+                                 'service implementation "car_service"'):
+        self.base.BaseCompute.register(Foo.TestService)(lambda x: 1)
 
   def test_getattr(self):
-    class Foo(base.BaseCompute):
+    class Foo(self.base.BaseCompute):
       def bar_service(self):
         pass
 
@@ -81,10 +78,14 @@ class TestServiceBase(TestCase):
 
 
 class TestUnitTests(TestCase):
+  def setUp(self):
+    from terra.compute import base
+    self.base = base
+
   def last_test_registered_services(self):
     self.assertFalse(
-      base.services,
-      msg="If you are seting this, one of the other unit tests has "
+      self.base.services,
+      msg="If you are seeing this, one of the other unit tests has "
       "registered a terra service. This side effect should be "
       "prevented by mocking out the terra.compute.base.services dict. "
       "Otherwise unit tests can interfere with each other.")

--- a/terra/tests/test_compute_container.py
+++ b/terra/tests/test_compute_container.py
@@ -1,14 +1,13 @@
 import os
 import ntpath
 import json
-import tempfile
 from unittest import mock, skipIf
 
 from terra import settings
 from terra.executor.utils import Executor
 from terra.compute import base
 import terra.compute.container
-from vsi.test.utils import TestCase, NamedTemporaryFileFactory
+from .utils import TestNamedTemporaryFileCase, TestSettingsUnconfiguredCase
 
 
 class SomeService(terra.compute.container.ContainerService):
@@ -30,11 +29,9 @@ def mock_map_lcow(self, *args, **kwargs):
   return [('/c/foo', '/bar')]
 
 
-class TestComputeContainerCase(TestCase):
+class TestComputeContainerCase(TestSettingsUnconfiguredCase):
   def setUp(self):
     self.temp_dir
-    # Use settings
-    self.patches.append(mock.patch.object(settings, '_wrapped', None))
     # This will resets the _connection to an uninitialized state
     self.patches.append(
         mock.patch.object(terra.compute.utils.ComputeHandler,
@@ -51,12 +48,11 @@ class TestComputeContainerCase(TestCase):
         'test_dir': '/opt/projects/terra/terra_dsm/external/terra/foo'})
 
 
-class TestContainerService(TestComputeContainerCase):
+class TestContainerService(TestComputeContainerCase,
+                           TestNamedTemporaryFileCase):
   # Test the flushing configuration to json for a container mechanism
 
   def setUp(self):
-    self.patches.append(mock.patch.object(tempfile, 'NamedTemporaryFile',
-                                          NamedTemporaryFileFactory(self)))
     self.patches.append(mock.patch.object(json, 'dump', self.json_dump))
     # self.common calls service.pre_run which trigger Executor
     self.patches.append(mock.patch.dict(Executor.__dict__))

--- a/terra/tests/test_compute_docker.py
+++ b/terra/tests/test_compute_docker.py
@@ -10,13 +10,11 @@ from terra.compute import base
 from terra.compute import docker
 import terra.compute.utils
 
-from .utils import TestCase
+from .utils import TestSettingsUnconfiguredCase
 
 
-class TestComputeDockerCase(TestCase):
+class TestComputeDockerCase(TestSettingsUnconfiguredCase):
   def setUp(self):
-    # Use settings
-    self.patches.append(mock.patch.object(settings, '_wrapped', None))
     # This will resets the _connection to an uninitialized state
     self.patches.append(
         mock.patch.object(terra.compute.utils.ComputeHandler,
@@ -102,7 +100,7 @@ class TestDockerRun(TestComputeDockerCase):
     compute.run(MockJustService())
     # Run a docker service
     self.assertEqual(('--wrap', 'Just-docker-compose',
-                      '-f', 'file1', 'run', 'launch', 'ls'),
+                      '-f', 'file1', 'run', '-T', 'launch', 'ls'),
                      self.just_args)
     self.assertEqual({'justfile': None, 'env': {'BAR': 'FOO'}},
                      self.just_kwargs)

--- a/terra/tests/test_compute_dummy.py
+++ b/terra/tests/test_compute_dummy.py
@@ -6,7 +6,7 @@ from terra.compute import base
 from terra.compute import dummy
 import terra.compute.utils
 
-from .utils import TestCase
+from .utils import TestSettingsUnconfiguredCase
 
 
 # Test Dummy Definition
@@ -31,10 +31,8 @@ class TestServiceManual_dummy(TestServiceManual, dummy.Service):
     self.d = 44
 
 
-class TestComputeDummyCase(TestCase):
+class TestComputeDummyCase(TestSettingsUnconfiguredCase):
   def setUp(self):
-    # Use settings
-    self.patches.append(mock.patch.object(settings, '_wrapped', None))
     # Use registry
     self.patches.append(mock.patch.dict(base.services, clear=True))
     # Use compute

--- a/terra/tests/test_compute_singularity.py
+++ b/terra/tests/test_compute_singularity.py
@@ -6,13 +6,11 @@ from terra.compute import base
 from terra.compute import singularity
 import terra.compute.utils
 
-from .utils import TestCase
+from .utils import TestSettingsUnconfiguredCase
 
 
-class TestComputeSingularityCase(TestCase):
+class TestComputeSingularityCase(TestSettingsUnconfiguredCase):
   def setUp(self):
-    # Use settings
-    self.patches.append(mock.patch.object(settings, '_wrapped', None))
     # This will resets the _connection to an uninitialized state
     self.patches.append(
         mock.patch.object(terra.compute.utils.ComputeHandler,

--- a/terra/tests/test_compute_utils.py
+++ b/terra/tests/test_compute_utils.py
@@ -3,7 +3,7 @@ from unittest import mock
 import warnings
 
 from terra import settings
-from .utils import TestCase
+from .utils import TestSettingsUnconfiguredCase
 import terra.compute.utils as utils
 import terra.compute.dummy
 import terra.compute.docker
@@ -34,7 +34,7 @@ class Service2_test:
 
 # I am purposefully showing multiple ways to mock _wrapped for demonstration
 # purposes
-class TestComputeUtilsCase(TestCase):
+class TestComputeUtilsCase(TestSettingsUnconfiguredCase):
   def setUp(self):
     # Use setting
     self.patches.append(mock.patch.object(settings, '_wrapped', None))
@@ -129,11 +129,11 @@ def mock_popen(*args, **kwargs):
 
 class TestBaseJust(TestComputeUtilsCase):
   def setUp(self):
-    self.patches.append(mock.patch.object(utils, 'Popen', mock_popen))
-    super().setUp()
-
     # Make a copy
     self.original_env = os.environ.copy()
+
+    self.patches.append(mock.patch.object(utils, 'Popen', mock_popen))
+    super().setUp()
 
   def tearDown(self):
     super().tearDown()
@@ -176,7 +176,7 @@ class TestBaseJust(TestComputeUtilsCase):
 
   def test_logging_code(self):
     # Test the debug1 diffdict log output
-    with self.assertLogs(utils.__name__, level="DEBUG1") as cm:
+    with self.assertLogs(utils.__name__, level="DEBUG4") as cm:
       env = os.environ.copy()
       env.pop('PATH')
       env['FOO'] = 'BAR'

--- a/terra/tests/test_compute_virtualenv.py
+++ b/terra/tests/test_compute_virtualenv.py
@@ -7,7 +7,7 @@ from terra.compute import base
 from terra.compute import virtualenv
 import terra.compute.utils
 
-from .utils import TestCase
+from .utils import TestSettingsUnconfiguredCase
 
 
 class MockVirtualEnvService(virtualenv.Service):
@@ -17,10 +17,8 @@ class MockVirtualEnvService(virtualenv.Service):
     self.env["BAR"] = "FOO"
 
 
-class TestVirtualEnv(TestCase):
+class TestVirtualEnv(TestSettingsUnconfiguredCase):
   def setUp(self):
-    # Use settings
-    self.patches.append(mock.patch.object(settings, '_wrapped', None))
     # self.run trigger Executor
     self.patches.append(mock.patch.dict(Executor.__dict__))
     # This will resets the _connection to an uninitialized state
@@ -37,7 +35,8 @@ class TestVirtualEnv(TestCase):
     # patches.append(mock.patch.dict(base.services, clear=True))
     super().setUp()
     settings.configure({
-        'compute': {'arch': 'virtualenv'},
+        'compute': {'arch': 'virtualenv',
+                    'virtualenv_dir': None},
         'processing_dir': self.temp_dir.name,
         'test_dir': '/opt/projects/terra/terra_dsm/external/terra/foo'})
 
@@ -98,7 +97,7 @@ class TestVirtualEnv(TestCase):
     service = MockVirtualEnvService()
 
     # Test logging code
-    with self.assertLogs(virtualenv.__name__, level="DEBUG1") as cm:
+    with self.assertLogs(virtualenv.__name__, level="DEBUG4") as cm:
       os.environ['BAR'] = 'FOO'
       env = os.environ.copy()
       env.pop('BAR')
@@ -110,10 +109,13 @@ class TestVirtualEnv(TestCase):
 
     env_lines = [x for x in cm.output if "Environment Modification:" in x][0]
     env_lines = env_lines.split('\n')
-    self.assertEqual(len(env_lines), 4)
+    self.assertEqual(len(env_lines), 5)
 
     self.assertTrue(any(o.startswith('- BAR:') for o in env_lines))
     self.assertTrue(any(o.startswith('+ FOO:') for o in env_lines))
     # Added by Terra
     self.assertTrue(any(o.startswith('+ TERRA_SETTINGS_FILE:')
+                        for o in env_lines))
+    # Added by TestSettingsUnconfiguredCase
+    self.assertTrue(any(o.startswith('- TERRA_SETTINGS_FILE:')
                         for o in env_lines))

--- a/terra/tests/test_executor_dummy.py
+++ b/terra/tests/test_executor_dummy.py
@@ -1,5 +1,5 @@
 from terra.executor import dummy
-from .utils import TestCase
+from .utils import TestSettingsConfiguredCase
 
 
 def test1(x):
@@ -10,7 +10,7 @@ def test2(x):
   return x + 13
 
 
-class TestExecutorDummy(TestCase):
+class TestExecutorDummy(TestSettingsConfiguredCase):
   def setUp(self):
     super().setUp()
     self.executor = dummy.DummyExecutor()

--- a/terra/tests/test_executor_utils.py
+++ b/terra/tests/test_executor_utils.py
@@ -1,19 +1,14 @@
-from unittest import mock, SkipTest
+from unittest import SkipTest
 import concurrent.futures
 
 from terra import settings
-from .utils import TestCase
+from .utils import TestCase, TestExecutorCase, TestSettingsUnconfiguredCase
 from terra.executor.utils import ExecutorHandler, Executor
 from terra.executor.dummy import DummyExecutor
 from terra.executor.sync import SyncExecutor
 
 
-class TestExecutorHandler(TestCase):
-  def setUp(self):
-    self.patches.append(mock.patch.object(settings, '_wrapped', None))
-    self.patches.append(mock.patch.dict(Executor.__dict__))
-    super().setUp()
-
+class TestExecutorHandler(TestExecutorCase, TestSettingsUnconfiguredCase):
   def test_executor_handler(self):
     settings.configure({'executor': {'type': 'DummyExecutor'}})
 

--- a/terra/tests/test_other.py
+++ b/terra/tests/test_other.py
@@ -1,0 +1,9 @@
+import os
+
+from .utils import TestCase
+from terra.tests import original_environ
+
+
+class TestOtherThings(TestCase):
+  def last_test_environ_change(self):
+    self.assertEqual(os.environ, original_environ)

--- a/terra/tests/test_signals.py
+++ b/terra/tests/test_signals.py
@@ -1,8 +1,8 @@
-from terra.core.signals import Signal, receiver, post_settings_configured
-from .utils import TestCase
+from terra.core.signals import Signal, receiver
+from .utils import TestSignalCase
 
 
-class TestSignals(TestCase):
+class TestSignals(TestSignalCase):
   def signal_handle1(self, sender, **kwargs):
     self.assertEqual(sender, self.sender)
     self.kwargs = kwargs
@@ -149,12 +149,16 @@ class TestSignals(TestCase):
     self.assertEqual(self.count, 1.1)
 
 
-class TestUnitTests(TestCase):
-  def last_test_signals(self):
-    for signal in [post_settings_configured]:
-      self.assertFalse(
-          signal.receivers,
-          msg="If you are seting this, one of the other unit tests has "
-          "left a signal connected. This side effect should be "
-          "prevented by disconnecting any functions you connected to a "
-          "signal.")
+# This no longer matters, as signals are disabled in unitted tests now?
+# class TestUnitTests(TestCase):
+#   def last_test_signals(self):
+#     for signal in [signals.post_settings_configured,
+#                    signals.post_settings_context,
+#                    signals.logger_configure,
+#                    signals.logger_reconfigure]:
+#       self.assertFalse(
+#           signal.receivers,
+#           msg="If you are seeing this, one of the other unit tests has "
+#               "left a signal connected. This side effect should "
+#               "be prevented by disconnecting any functions you connected to "
+#               "a signal.")

--- a/terra/tests/test_utils_workflow.py
+++ b/terra/tests/test_utils_workflow.py
@@ -1,27 +1,18 @@
-from unittest import mock
 import re
-import os
 import json
 
 from terra.utils.workflow import resumable, AlreadyRunException
 from terra import settings
 from terra.logger import DEBUG1
-from .utils import TestCase
+from .utils import TestSettingsUnconfiguredCase
 
 
 class Klass:
   pass
 
 
-class TestResumable(TestCase):
-  def __init__(self, *args, **kwargs):
-    super().__init__(*args, **kwargs)
-    self.patches = []
-
+class TestResumable(TestSettingsUnconfiguredCase):
   def setUp(self):
-    self.patches.append(mock.patch.dict(os.environ,
-                                        {'TERRA_SETTINGS_FILE': ""}))
-    self.patches.append(mock.patch.object(settings, '_wrapped', None))
     super().setUp()
     settings.configure({'processing_dir': self.temp_dir.name})
 

--- a/terra/tests/utils.py
+++ b/terra/tests/utils.py
@@ -1,5 +1,112 @@
+import os
+import sys
+import json
+from unittest import mock
+
 from vsi.test.utils import (
-  TestCase, make_traceback
+  TestCase, make_traceback, TestNamedTemporaryFileCase
 )
 
-__all__ = ["TestCase", "make_traceback"]
+from terra import settings
+
+
+__all__ = ["TestCase", "make_traceback", "TestNamedTemporaryFileCase",
+           "TestSettingsUnconfiguredCase", "TestSettingsConfiguredCase",
+           "TestComputeCase", "TestExecutorCase", "TestSignalCase",
+           "TestLoggerConfigureCase"]
+
+
+class TestSettingsUnconfiguredCase(TestCase):
+  def __init__(self, *args, **kwargs):
+    self.settings_filename = ''
+    super().__init__(*args, **kwargs)
+
+  def setUp(self):
+    # Useful for tests that set this
+    self.patches.append(mock.patch.dict(
+        os.environ,
+        {'TERRA_SETTINGS_FILE': self.settings_filename}))
+    # Use settings
+    self.patches.append(mock.patch.object(settings, '_wrapped', None))
+    super().setUp()
+
+
+class TestSettingsConfiguredCase(TestSettingsUnconfiguredCase):
+  def setUp(self):
+    super().setUp()
+    settings.configure({})
+
+
+class TestLoggerCase(TestSettingsUnconfiguredCase, TestNamedTemporaryFileCase):
+  def setUp(self):
+    self.original_system_hook = sys.excepthook
+    attrs = {'serve_until_stopped.return_value': True, 'ready': True}
+    MockLogRecordSocketReceiver = mock.Mock(**attrs)
+    self.patches.append(mock.patch('terra.logger.LogRecordSocketReceiver',
+                                   MockLogRecordSocketReceiver))
+    self.patches.append(mock.patch(
+        'terra.compute.base.LogRecordSocketReceiver',
+        MockLogRecordSocketReceiver))
+    # Special customization of TestSettingsUnconfiguredCase
+    self.settings_filename = os.path.join(self.temp_dir.name, 'config.json')
+    config = {"processing_dir": self.temp_dir.name}
+    with open(self.settings_filename, 'w') as fid:
+      json.dump(config, fid)
+
+    super().setUp()
+
+    # Run _setup_terra_logger AFTER the patches have been applied, or else the
+    # temp files will be in /tmp, not self.temp_dir, and the terra_initial_tmp_
+    # files won't get auto cleaned up
+    import terra.logger
+    self._logs = terra.logger._setup_terra_logger()
+
+  def tearDown(self):
+    sys.excepthook = self.original_system_hook
+
+    try:
+      self._logs.log_file.close()
+    except AttributeError:
+      pass
+    # Windows is pickier about deleting files
+    try:
+      if self._logs.tmp_file:
+        self._logs.tmp_file.close()
+    except AttributeError:
+      pass
+    self._logs.root_logger.handlers = []
+    import terra.core.signals
+    terra.core.signals.post_settings_configured.disconnect(
+        self._logs.configure_logger)
+    terra.core.signals.post_settings_context.disconnect(
+        self._logs.reconfigure_logger)
+    super().tearDown()
+
+
+class TestComputeCase(TestCase):
+  def setUp(self):
+    import terra.compute.utils
+    self.patches.append(mock.patch.dict(terra.compute.utils.compute.__dict__))
+    super().setUp()
+
+
+class TestExecutorCase(TestCase):
+  def setUp(self):
+    import terra.executor.utils
+    self.patches.append(mock.patch.dict(
+        terra.executor.utils.Executor.__dict__))
+    super().setUp()
+
+
+class TestSignalCase(TestCase):
+  def setUp(self):
+    self.patches.append(mock.patch.dict(os.environ, TERRA_UNITTEST='0'))
+    super().setUp()
+
+
+# Enable signals. Most logging tests require configure logger to actually
+# be called. LogRecordSocketReceiver is mocked out, so no lasting side
+# effects should inccur.
+class TestLoggerConfigureCase(TestLoggerCase, TestSignalCase,
+                              TestComputeCase, TestExecutorCase):
+  pass

--- a/terra/workflow.py
+++ b/terra/workflow.py
@@ -1,3 +1,6 @@
+from uuid import uuid4
+from datetime import datetime
+
 from terra import settings
 from terra.logger import getLogger
 logger = getLogger(__name__)
@@ -7,6 +10,10 @@ class BaseWorkflow:
   '''
   The base class for all Terra Workflows
   '''
+
+  def __init__(self):
+    self.uuid = uuid4()
+    self.start_time = datetime.now()
 
   def run(self):
     pass
@@ -21,6 +28,7 @@ class PipelineWorkflow:
 
   def __init__(self):
     self.pipeline = list()
+    super().__init__()
 
   # locate index of service name in workflow pipeline
   def service_index(self, service_name=None, default_index=0):


### PR DESCRIPTION
Finalize working support for celery executor and multiprocess logging

Added
- Added settings.terra.zone to settings
- Added zone to logging
- Added color formatter to logging
- Added Debug4 level to logging
- Added terra.tests.demo app and service for testing config file in.
- Terra demo app auto added to celery apps
- TERRA_KEEP_TEMP_DIR env var to keep temp autogenerated files for debugging
- Celery has a fourth zone known as task_controller for the celery worker's
  parent
- Executors have a volume map translation too
- Task kwargs and returns values are can have map translation applied to them
- ConfigurationWarning
- Each run of a terra app gets assigned a UUID, settings.terra.uuid
- All multi processing processes use a TCP server for sending logs, using
  settings.logging.server.hostname and settings.logging.server.port
- Settings can be pickled
- terra.logging.LogRecordStreamHandler to log out to TCP
- terra.logging.LogRecordSocketReceiver to run a threaded server to receive TCP
  log messages
- Terra's own task class, terra.task.TerraTask

Changes
- TERRA_CELERY_MAIN_NAME is now auto deteremined by default. It only has to be
  set if the main App CLI is a built-in (aka compiled python module) which is
  not typical.
- Computes are now responsible for configuring and reconfiguring the logger for
  controller and runners zones
- Executors are now responsible for configuring and reconfiguring the logger
  for task zones
- Executor and compute volume maps are stored in settings now.
- Settings files dumped during processing contain the uuid, to make determining
  which run is which easier.
- All executors (including thread/process) inherit from
  terra.executor.base.BaseExecutor
- Celery CLI is no longer called directly, instead terra.executor.celery should
  be called
- Celery logging facilities are disabled, only terra logging used now
- terra.logging.get_logger -> terra.logging.getLogger
- Default format includes hostname and zone.
- Runner and tasks no longer output log messages to stderr. Instead the master
  controller will output the runner's and task's messages (received via TCP)
  itself, to stderr.
- Uncaught exceptions stack traces now have a header with the hostname and zone
- Uncaught exceptions are no longer printed twice due to logging
- logging file_handler -> main_log_handler
- hostname, zone, and other logging settings set with filters instead of
  formatters or "extra" variables, it is a more universal entrypoint for adding
  values
- Tasks should now be decorated with terra.task.shared_task

Bug Fixes
- Fixed new? bug on CI with flake8 being run in the wrong directory, not finding
  the config file all of a sudden
- Fixed typos in Redis command secret file variable names, causing the wrong
  variable to be used
- Added celery as a dependency of terra
- Removed invalid password characters from auto generated redis password
- Docker compute use non-TTY containers, to fix a stdout nl/cr bug
- Remove duplicated volumes in singularity
- Not setting the virtualenv_dir in virtualenv compute now issues a warning
- Fixed tilde expantion in settings.
- Celery shutdown uses a tuple of self._futures to create a copy of futures and
  prevent a race condition
- Catch file not existing when deleting tmp_file

Testing
- Check to see if any test permanently modifies os.environ by accident
- Refactors test cases so settings, logging and other specical cases are all
  handled by Test Cases classes in terra.tests.utils
- TestSettingsUnconfiguredCase prepares terra.core.settings, but leaves it
  unconfigured
- TestSettingsConfiguredCase, same as TestSettingsUnconfiguredCase, but
  configures it using an empty dictionary.
- TestLoggerCase - An Unconfigured Settings case, that uses a modified temp dir
  function so that all temp files are created in the test dir, preventing /tmp
  from being spammed with temp terra log files. Also mocks the TCP server so the
  TCP server thread is not actually started.
- TestComputeCase - Allows for a compute backend to be loaded
- TestExecutorCase - Allows for an executor backend to be loaded.
- TestSignalCase - Enables signals. By default, signals are disabled for all
  unit tests.
- TestLoggerConfigureCase - Test logging with settings configured and signals
  enabled, but TCP Server is still disabled.