### PR TITLE
Added error handling for common terra issues

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -101,6 +101,7 @@ function terra_caseify()
 
     ### Running containers ###
     run) # Run python module/cli in terra
+      local JUST_IGNORE_EXIT_CODES=62
       if [[ ${JUST_RODEO-} == 1 ]]; then
         extra_args=$#
         local app_name="${1}"

--- a/terra/core/exceptions.py
+++ b/terra/core/exceptions.py
@@ -1,6 +1,7 @@
 
 handledExitCode = 62  # 20 + 5 + 18 + 18 + 1
 
+
 class ImproperlyConfigured(Exception):
   """
   Exception for Terra is somehow improperly configured
@@ -10,9 +11,4 @@ class ImproperlyConfigured(Exception):
 class ConfigurationWarning(Warning):
   """
   Warning that Terra may be improperly configured
-  """
-
-class JsonError(Exception):
-  """
-  Exception for bas json file
   """

--- a/terra/core/exceptions.py
+++ b/terra/core/exceptions.py
@@ -1,3 +1,6 @@
+
+handledExitCode = 62  # 20 + 5 + 18 + 18 + 1
+
 class ImproperlyConfigured(Exception):
   """
   Exception for Terra is somehow improperly configured
@@ -7,4 +10,9 @@ class ImproperlyConfigured(Exception):
 class ConfigurationWarning(Warning):
   """
   Warning that Terra may be improperly configured
+  """
+
+class JsonError(Exception):
+  """
+  Exception for bas json file
   """

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -529,7 +529,7 @@ class LazySettings(LazyObject):
       if getattr(json_file, 'settings_property', None):
         json_file = json_file(settings)
 
-      return Settings(json_load(settings_file))
+      return Settings(json_load(json_file))
 
     nested_patch_inplace(
         self._wrapped,

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -798,10 +798,11 @@ def json_load(filename):
     with open(filename, 'r') as fid:
       return json.load(fid)
   except JSONDecodeError as e:
-    logger.error(f'Error parsing the JSON config file {filename}: ' + str(e))
+    logger.critical(
+        f'Error parsing the JSON config file {filename}: ' + str(e))
     raise SystemExit(handledExitCode)
   except FileNotFoundError as e:
-    logger.error('Cannot find JSON config file: ' + str(e))
+    logger.critical('Cannot find JSON config file: ' + str(e))
     raise SystemExit(handledExitCode)
 
 

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -161,7 +161,7 @@ import copy
 from json.decoder import JSONDecodeError
 
 from terra.core.exceptions import (
-  ImproperlyConfigured, ConfigurationWarning, JsonError, handledExitCode
+  ImproperlyConfigured, ConfigurationWarning, handledExitCode
 )
 # Do not import terra.logger or terra.signals here, or any module that
 # imports them
@@ -791,6 +791,7 @@ class TerraJSONEncoder(JSONEncoder):
         Object to be converted to json friendly :class:`dict`
     '''
     return json.dumps(obj, cls=TerraJSONEncoder, **kwargs)
+
 
 def json_load(filename):
   # Helper function to load from json


### PR DESCRIPTION
Create graceful errors for Config JSON parsing errors and config file not found.

Some error, we know what is wrong, and a stack trace is not necessary. Furthermore, they are user based errors (Like bad json filename or json malformed) and a stack trace is not needed for the user.

Now, instead of raising an exception when we know the error, and having a nasty backtrace printed out, we can `raise SystemExit(terra.core.exceptions.handledExitCode` and now Python and Just will not print out a stack. A `logger.critical` should precede the `SystemExit`, or else the user will not see what is wrong. 