### PR TITLE
Fix processing dir default

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -101,6 +101,7 @@ function terra_caseify()
 
     ### Running containers ###
     run) # Run python module/cli in terra
+      local JUST_IGNORE_EXIT_CODES=62
       if [[ ${JUST_RODEO-} == 1 ]]; then
         extra_args=$#
         local app_name="${1}"

--- a/terra/core/exceptions.py
+++ b/terra/core/exceptions.py
@@ -1,3 +1,7 @@
+
+handledExitCode = 62  # 20 + 5 + 18 + 18 + 1
+
+
 class ImproperlyConfigured(Exception):
   """
   Exception for Terra is somehow improperly configured

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -253,22 +253,19 @@ def config_file(self):
   '''
   A :func:`settings_property` for passing the filename of the config_file to
   settings
-
-  There was a chicken-egg problem with determing settings.processing_dir
-
-  Call _setup
-  - Calls configure
-    Send signal
-      - Logger receives signal, and start setting up logger
-      - Needs to know where to put log files, so check
-        settings.processing_dir
-      - settings.processing_dir looks for setttings.terra.config_file,
-        doesn't see it yet
-  - Returns to _setup
-  - Then set settings.terra.config_file.
-
-  This is used to get around the problem
   '''
+  # There was a chicken-egg problem with determing settings.processing_dir:
+  # #. Call ``_setup``
+  #   #. Calls ``configure``
+  #   #. Send signal
+  #     #. Logger receives signal, and start setting up logger
+  #     #. Needs to know where to put log files, so check
+  #        ``settings.processing_dir``
+  #     #. settings.processing_dir looks for `setttings.terra.config_file``,
+  #        doesn't see it yet
+  # 2. Returns to ``_setup``
+  # #. Then set ``settings.terra.config_file``, but it's too late
+  # This will around the problem
   return config_file.filename
 
 

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -158,8 +158,11 @@ import warnings
 import threading
 import concurrent.futures
 import copy
+from json.decoder import JSONDecodeError
 
-from terra.core.exceptions import ImproperlyConfigured, ConfigurationWarning
+from terra.core.exceptions import (
+  ImproperlyConfigured, ConfigurationWarning, handledExitCode
+)
 # Do not import terra.logger or terra.signals here, or any module that
 # imports them
 from vsi.tools.python import (
@@ -463,8 +466,7 @@ class LazySettings(LazyObject):
           "You must either define the environment variable %s "
           "or call settings.configure() before accessing settings." %
           (desc, ENVIRONMENT_VARIABLE))
-    with open(settings_file) as fid:
-      self.configure(json.load(fid))
+    self.configure(json_load(settings_file))
     # Cover corner case that can only really happens in testing
     if not hasattr(self, 'terra'):
       self.terra = {}
@@ -527,8 +529,7 @@ class LazySettings(LazyObject):
       if getattr(json_file, 'settings_property', None):
         json_file = json_file(settings)
 
-      with open(json_file, 'r') as fid:
-        return Settings(json.load(fid))
+      return Settings(json_load(json_file))
 
     nested_patch_inplace(
         self._wrapped,
@@ -790,6 +791,20 @@ class TerraJSONEncoder(JSONEncoder):
         Object to be converted to json friendly :class:`dict`
     '''
     return json.dumps(obj, cls=TerraJSONEncoder, **kwargs)
+
+
+def json_load(filename):
+  # Helper function to load from json
+  try:
+    with open(filename, 'r') as fid:
+      return json.load(fid)
+  except JSONDecodeError as e:
+    logger.critical(
+        f'Error parsing the JSON config file {filename}: ' + str(e))
+    raise SystemExit(handledExitCode)
+  except FileNotFoundError as e:
+    logger.critical('Cannot find JSON config file: ' + str(e))
+    raise SystemExit(handledExitCode)
 
 
 import terra.logger  # noqa

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -231,10 +231,9 @@ def processing_dir(self):
 
   If the directory is not writeable, a temporary directory will be used instead
   '''
-
-  if hasattr(self.terra, 'config_file'):
+  try:
     processing_dir = os.path.dirname(self.terra.config_file)
-  else:
+  except Exception:
     processing_dir = os.getcwd()
     logger.warning('No config file found, and processing dir unset. '
                    f'Using cwd: {processing_dir}')
@@ -247,6 +246,33 @@ def processing_dir(self):
                  f'Using "{processing_dir}" instead')
 
   return processing_dir
+
+
+@settings_property
+def config_file(self):
+  '''
+  A :func:`settings_property` for passing the filename of the config_file to
+  settings
+
+  There was a chicken-egg problem with determing settings.processing_dir
+
+  Call _setup
+  - Calls configure
+    Send signal
+      - Logger receives signal, and start setting up logger
+      - Needs to know where to put log files, so check
+        settings.processing_dir
+      - settings.processing_dir looks for setttings.terra.config_file,
+        doesn't see it yet
+  - Returns to _setup
+  - Then set settings.terra.config_file.
+
+  This is used to get around the problem
+  '''
+  return config_file.filename
+
+
+config_file.filename = None
 
 
 @settings_property
@@ -303,6 +329,7 @@ global_templates = [
         'volume_map': []
       },
       'terra': {
+        'config_file': config_file,
         # unlike other settings, this should NOT be overwritten by a
         # config.json file, there is currently nothing to prevent that
         'zone': 'controller',
@@ -466,11 +493,9 @@ class LazySettings(LazyObject):
           "You must either define the environment variable %s "
           "or call settings.configure() before accessing settings." %
           (desc, ENVIRONMENT_VARIABLE))
+    # Store in global variable :-\
+    config_file.filename = settings_file
     self.configure(json_load(settings_file))
-    # Cover corner case that can only really happens in testing
-    if not hasattr(self, 'terra'):
-      self.terra = {}
-    self.terra.config_file = settings_file
 
   def __getstate__(self):
     if self._wrapped is None:

--- a/terra/tests/utils.py
+++ b/terra/tests/utils.py
@@ -28,6 +28,9 @@ class TestSettingsUnconfiguredCase(TestCase):
         {'TERRA_SETTINGS_FILE': self.settings_filename}))
     # Use settings
     self.patches.append(mock.patch.object(settings, '_wrapped', None))
+    import terra.core.settings
+    self.patches.append(mock.patch.object(terra.core.settings.config_file,
+                                          'filename', None))
     super().setUp()
 
 


### PR DESCRIPTION
The code for using `settings.terra.config_file` to determine `settings.processing_dir` was not working due to a chicken-egg issue.

#### Call _setup
- Calls configure
- Send signal
    - Logger receives signal, and start setting up logger
    - Needs to know where to put log files, so check `settings.processing_dir`
    - `settings.processing_dir` looks for `setttings.terra.config_file`, doesn't see it yet
- Returns to _setup
- Then set `settings.terra.config_file`, but it's too late

The solution was essentially to use a global/singleton variable 😞 to get around this issue.