### PR TITLE
settings_dump_dir

### DIFF
--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -50,6 +50,13 @@ class ContainerService(BaseService):
         f'{str(temp_dir)}:/tmp_settings:rw'
     env_volume_index += 1
 
+    if os.environ.get('TERRA_DISABLE_SETTINGS_DUMP') != '1':
+      os.makedirs(settings.settings_dump_dir, exist_ok=True)
+      self.env[f'{self.env["JUST_PROJECT_PREFIX"]}_'
+               f'VOLUME_{env_volume_index}'] = \
+          f'{settings.settings_dump_dir}:/settings_dump:rw'
+      env_volume_index += 1
+
     # Copy self.volumes to the environment variables
     for _, ((volume_host, volume_container), volume_flags) in \
         enumerate(zip(self.volumes, self.volumes_flags)):

--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -54,7 +54,7 @@ class ContainerService(BaseService):
       os.makedirs(settings.settings_dir, exist_ok=True)
       self.env[f'{self.env["JUST_PROJECT_PREFIX"]}_'
                f'VOLUME_{env_volume_index}'] = \
-          f'{settings.settings_dir}:/settingsrw'
+          f'{settings.settings_dir}:/settings:rw'
       env_volume_index += 1
 
     # Copy self.volumes to the environment variables

--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -51,10 +51,10 @@ class ContainerService(BaseService):
     env_volume_index += 1
 
     if os.environ.get('TERRA_DISABLE_SETTINGS_DUMP') != '1':
-      os.makedirs(settings.settings_dump_dir, exist_ok=True)
+      os.makedirs(settings.settings_dir, exist_ok=True)
       self.env[f'{self.env["JUST_PROJECT_PREFIX"]}_'
                f'VOLUME_{env_volume_index}'] = \
-          f'{settings.settings_dump_dir}:/settings_dump:rw'
+          f'{settings.settings_dir}:/settingsrw'
       env_volume_index += 1
 
     # Copy self.volumes to the environment variables

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -222,6 +222,16 @@ def status_file(self):
 
 
 @settings_property
+def settings_dump_dir(self):
+  '''
+  The default :func:`settings_property` for settings dumps as JSON files.
+  The default location is :func:`processing_dir/settings_dump`.
+  This directory is not used if ``TERRA_DISABLE_SETTINGS_DUMP`` is true.
+  '''
+  return os.path.join(self.processing_dir, 'settings_dump')
+
+
+@settings_property
 def processing_dir(self):
   '''
   The default :func:`settings_property` for the processing directory. If not
@@ -333,6 +343,7 @@ global_templates = [
         # 'start_time': datetime.now(), # Not json serializable yet
         'uuid': terra_uuid
       },
+      'settings_dump_dir': settings_dump_dir,
       'status_file': status_file,
       'processing_dir': processing_dir,
       'unittest': unittest,

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -225,7 +225,7 @@ def status_file(self):
 def settings_dump_dir(self):
   '''
   The default :func:`settings_property` for settings dumps as JSON files.
-  The default location is :func:`processing_dir/settings_dump`.
+  The default is :func:`processing_dir/settings_dump<processing_dir>`.
   This directory is not used if ``TERRA_DISABLE_SETTINGS_DUMP`` is true.
   '''
   return os.path.join(self.processing_dir, 'settings_dump')

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -222,13 +222,13 @@ def status_file(self):
 
 
 @settings_property
-def settings_dump_dir(self):
+def settings_dir(self):
   '''
   The default :func:`settings_property` for settings dumps as JSON files.
-  The default is :func:`processing_dir/settings_dump<processing_dir>`.
+  The default is :func:`processing_dir/settings<processing_dir>`.
   This directory is not used if ``TERRA_DISABLE_SETTINGS_DUMP`` is true.
   '''
-  return os.path.join(self.processing_dir, 'settings_dump')
+  return os.path.join(self.processing_dir, 'settings')
 
 
 @settings_property
@@ -343,7 +343,7 @@ global_templates = [
         # 'start_time': datetime.now(), # Not json serializable yet
         'uuid': terra_uuid
       },
-      'settings_dump_dir': settings_dump_dir,
+      'settings_dir': settings_dir,
       'status_file': status_file,
       'processing_dir': processing_dir,
       'unittest': unittest,

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -431,8 +431,9 @@ class _SetupTerraLogger():
     self.root_logger.removeHandler(self.tmp_handler)
 
     if os.environ.get('TERRA_DISABLE_SETTINGS_DUMP') != '1':
+      os.makedirs(settings.settings_dump_dir, exist_ok=True)
       settings_dump = os.path.join(
-          settings.processing_dir,
+          settings.settings_dump_dir,
           datetime.now(timezone.utc).strftime(
               f'settings_{settings.terra.uuid}_%Y_%m_%d_%H_%M_%S_%f.json'))
       with open(settings_dump, 'w') as fid:

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -431,9 +431,9 @@ class _SetupTerraLogger():
     self.root_logger.removeHandler(self.tmp_handler)
 
     if os.environ.get('TERRA_DISABLE_SETTINGS_DUMP') != '1':
-      os.makedirs(settings.settings_dump_dir, exist_ok=True)
+      os.makedirs(settings.settings_dir, exist_ok=True)
       settings_dump = os.path.join(
-          settings.settings_dump_dir,
+          settings.settings_dir,
           datetime.now(timezone.utc).strftime(
               f'settings_{settings.terra.uuid}_%Y_%m_%d_%H_%M_%S_%f.json'))
       with open(settings_dump, 'w') as fid:


### PR DESCRIPTION
Save settings dump files to `settings_dump_dir`, defaulting to the directory `processing_dir\settings_dump`.  This should eliminate the need for apps to mount the processing directory.