### PR TITLE
pathlib for volume_map translation

### DIFF
--- a/terra/compute/utils.py
+++ b/terra/compute/utils.py
@@ -34,7 +34,6 @@ from shlex import quote
 from subprocess import Popen
 import distutils.spawn
 import pathlib
-import ntpath
 
 from vsi.tools.diff import dict_diff
 from vsi.tools.python import nested_patch

--- a/terra/tests/test_compute_utils.py
+++ b/terra/tests/test_compute_utils.py
@@ -1,3 +1,6 @@
+import ntpath
+import pathlib
+import posixpath
 import os
 from unittest import mock
 import warnings
@@ -195,3 +198,83 @@ class TestBaseJust(TestComputeUtilsCase):
     # JUSTFILE was changed
     self.assertTrue(any(o.startswith('+ JUSTFILE:') for o in env_lines))
     self.assertTrue(any(o.startswith('- JUSTFILE:') for o in env_lines))
+
+
+class TestTranslateUtils(TestComputeUtilsCase):
+
+  def _nt_or_posix(self, nt_obj, posix_obj, platform):
+    return nt_obj if platform in ('windows', 'nt') else posix_obj
+
+  def _drive(self, host_platform, container_platform):
+    return (self._nt_or_posix('H:\\', '/', host_platform),
+            self._nt_or_posix('C:\\', '/', container_platform))
+
+  def _os(self, host_platform, container_platform):
+    return (self._nt_or_posix(ntpath, posixpath, host_platform),
+            self._nt_or_posix(ntpath, posixpath, container_platform))
+
+  def _create_volume_map(self, host_platform, container_platform):
+
+    # test data
+    test_data = [
+        (('src', 'abc'), ('dst', 'ABC')),
+        (('src', 'abc_output'), ('dst', 'OUTPUT')),
+        (('src', 'def'), ('dst', 'DEF')),
+        (('src', 'abc.json'), ('dst', 'ABC.json')),
+    ]
+
+    # append "drive" to test data
+    host_drv, container_drv = self._drive(host_platform, container_platform)
+    test_data = [((host_drv, *src), (container_drv, *dst))
+                 for src, dst in test_data]
+
+    # volume map
+    host_os, container_os = self._os(host_platform, container_platform)
+    volume_map = [(host_os.join(*src), container_os.join(*dst))
+                  for src, dst in test_data]
+    return volume_map
+
+  def _test_pathlib_map(self, container_platform):
+    host_obj_type = type(pathlib.Path())
+    container_obj_type = self._nt_or_posix(pathlib.PureWindowsPath,
+                                           pathlib.PurePosixPath,
+                                           container_platform)
+
+    volume_map = self._create_volume_map(os.name, container_platform)
+    pathlib_map = utils.pathlib_map(volume_map, container_platform)
+
+    for host_obj, container_obj in pathlib_map:
+      self.assertIsInstance(host_obj, host_obj_type)
+      self.assertIsInstance(container_obj, container_obj_type)
+
+  def test_pathlib_map_linux(self):
+    self._test_pathlib_map('linux')
+
+  def test_pathlib_map_windows(self):
+    self._test_pathlib_map('windows')
+
+  def _test_patch_volume(self, container_platform):
+    volume_map = self._create_volume_map(os.name, container_platform)
+    host_os, container_os = self._os(os.name, container_platform)
+
+    for host_vol, container_vol in volume_map:
+      is_file = '.' in pathlib.Path(host_vol).parts[-1]
+      if is_file:
+        # direct file mapping only
+        test_items = [[]]
+      else:
+        # this directory, subdirectory, and file mappings
+        test_items = [[], ['xyz'], ['xyz', 'xyz']]
+        test_items += [[*ti, 'file.json'] for ti in test_items]
+
+      for item in test_items:
+        host_item = host_os.join(host_vol, *item)
+        container_item = container_os.join(container_vol, *item)
+        result = utils.patch_volume(host_item, volume_map, container_platform)
+        self.assertEqual(result, container_item)
+
+  def test_patch_volume_linux(self):
+    self._test_patch_volume('linux')
+
+  def test_patch_volume_windows(self):
+    self._test_patch_volume('windows')


### PR DESCRIPTION
Use pathlib for `compute.utils.translate_settings_paths` for all flavors of `container_platform`.  Additionally break path translation steps into separate functions for more unit tests.

This addresses a bug where a user has the following setup, where the output directory starts with the same string as the input directory (though output and input are separate folders).  This is a valid configuration and should be handled.

- Input path = `/path/to/data`
- Output path = `/path/to/data_output`

Consider the following configuration:
```
{
  "image_dir": "/path/to/data",
  "service_dir": "/path/to/data_output/service",
}
```

And the following volume_map:
```
[
  ["/path/to/data_output/service", "/dem/service"],
  ["/path/to/data", "/dem/images"]
]
```

A volume_map using string comparison produces the following incorrect translation. Note volume_map tuples are applied in reverse order to each configuration option until a match is found.
```
{
  "image_dir": "/dem/images",
  "service_dir": "/dem/images_output/service",  # "/path/to/data_output/service".startswith("path/to/data")
}
```

Using pathlib comparison, volume mappings match to directories/files only & produce the expected translation:
```
{
  "image_dir": "/dem/images",
  "service_dir": "/dem/service",
}
```
