### PR TITLE
dynamic logging_hostname

### DIFF
--- a/terra.env
+++ b/terra.env
@@ -104,6 +104,10 @@ fi
 # .. envvar:: TERRA_DISABLE_TERRA_LOG
 #
 # Optional environment variable that, when set to ``1``, will disable the saving of the ``terra_log`` file in the processing dir. This is particularly useful for test script or jupyter notebooks where you do not want to litter ``terra_log`` files everywhere. For debug use.
+#
+# .. envvar:: TERRA_RESOLVE_HOSTNAME
+#
+# Optional environment variable that, when set to ``1``, will attempt to resolve the IP of the default route on the host machine.  This may correct some situations when the ``terra_log`` is missing service & task logging information due to invalid hostname resolution by the logging module.
 #**
 
 #**


### PR DESCRIPTION
dynamic settings `logging_hostname` and environment variable `TERRA_RESOLVE_HOSTNAME` that attempts to resolve the IP of the default route on the host as per https://stackoverflow.com/a/28950776.  This optional setting can overcome situations where the logging module fails to resolve the hostname, resulting in missing service & task logs from `terra_log`

By default, we maintain current operation of `hostname == platform.node()`.  User must explicitly enable resolution by setting `TERRA_RESOLVE_HOSTNAME=1`.

