### PR TITLE
Justfile: get-pipenv -> 30_get-pipenv

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -368,7 +368,7 @@ function terra_caseify()
         echo
       fi
 
-      source "${VSI_COMMON_DIR}/docker/recipes/get-pipenv"
+      source "${VSI_COMMON_DIR}/docker/recipes/30_get-pipenv"
       PIPENV_PYTHON="${PYTHON}" PIPENV_VIRTUALENV="${output_dir}" install_pipenv
 
       local add_to_local


### PR DESCRIPTION
Update Justfile for file name change (`get-pipenv` -> `30_get-pipenv`) in `vsi_common/docker/recipes` introduced by https://github.com/VisionSystemsInc/docker_recipes/pull/14