### PR TITLE
logging listen address

### DIFF
--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -210,7 +210,8 @@ class BaseCompute:
 
       # setup the TCP socket listener
       sender.tcp_logging_server = LogRecordSocketReceiver(
-          settings.logging.server.hostname, settings.logging.server.port)
+          settings.logging.server.listen_address,
+          settings.logging.server.port)
       listener_thread = threading.Thread(
           target=sender.tcp_logging_server.serve_until_stopped)
       listener_thread.setDaemon(True)

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -332,6 +332,18 @@ def logging_hostname(self):
   return platform.node()
 
 
+@settings_property
+def logging_listen_address(self):
+  '''
+  A :func:`settings_property` defining the address on which the main
+  logger will listen. In some environments this may need to be overridden
+  (e.g., ``0.0.0.0``) to ensure appropriate capture of service & task logs.
+  '''
+
+  # is 0.0.0.0 as default better?
+  return self.logging.server.hostname
+
+
 global_templates = [
   (
     # Global Defaults
@@ -349,7 +361,8 @@ global_templates = [
           # master controller's values, not their node names, should they be
           # different (such as celery and spark)
           "hostname": logging_hostname,
-          "port": DEFAULT_TCP_LOGGING_PORT
+          "port": DEFAULT_TCP_LOGGING_PORT,
+          "listen_address": logging_listen_address,
         }
       },
       "executor": {


### PR DESCRIPTION
Add `settings.logging.server.listen_address`, allowing the logging server listen address to be overridden.  For example, the logging server may be bound to the more permissive `0.0.0.0`, while logging clients transmit to the actual host IP.