### PR TITLE
Patch for Issue #55

### DIFF
--- a/terra/task.py
+++ b/terra/task.py
@@ -130,13 +130,17 @@ class TerraTask(Task):
     else:
       # Must call (synchronous) apply or python __call__ with no volume
       # mappings
+      # Use a flag for people who are somehow getting here with settings
+      # unconfigured
+      saved_original_zone = False
       if settings.configured:
+        saved_original_zone = True
         original_zone = settings.terra.zone
       settings.terra.zone = 'task'
       try:
         return_value = self.run(*args, **kwargs)
       finally:
-        if settings.configured:
+        if saved_original_zone:
           settings.terra.zone = original_zone
     return return_value
 

--- a/terra/task.py
+++ b/terra/task.py
@@ -132,15 +132,14 @@ class TerraTask(Task):
       # mappings
       # Use a flag for people who are somehow getting here with settings
       # unconfigured
-      saved_original_zone = False
+      original_zone = None
       if settings.configured:
-        saved_original_zone = True
         original_zone = settings.terra.zone
       settings.terra.zone = 'task'
       try:
         return_value = self.run(*args, **kwargs)
       finally:
-        if saved_original_zone:
+        if original_zone is not None:
           settings.terra.zone = original_zone
     return return_value
 


### PR DESCRIPTION
Fixes the issue in windows when running a task can cause

```
Traceback (most recent call last):
  File "...\Python37_64\Lib\concurrent\futures\process.py", line 239, in _process_worker
    r = call_item.fn(*call_item.args, **call_item.kwargs)
  File "...\terra\terra\task.py", line 140, in __call__
    settings.terra.zone = original_zone
UnboundLocalError: local variable 'original_zone' referenced before assignment
```