### PR TITLE
WIP: Default service start / end

### DIFF
--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -383,6 +383,8 @@ global_templates = [
         # 'start_time': datetime.now(), # Not json serializable yet
         'uuid': terra_uuid
       },
+      "service_start": None,
+      "service_end": None,
       'settings_dir': settings_dir,
       'status_file': status_file,
       'processing_dir': processing_dir,

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -153,6 +153,7 @@ from logging.handlers import DEFAULT_TCP_LOGGING_PORT
 from inspect import isfunction
 from functools import wraps
 from json import JSONEncoder
+import multiprocessing
 import socket
 import platform
 import warnings
@@ -366,6 +367,7 @@ global_templates = [
         }
       },
       "executor": {
+        "num_workers": multiprocessing.cpu_count(),
         "type": "ProcessPoolExecutor",
         'volume_map': []
       },


### PR DESCRIPTION
workflow.py references settings.service_start and settings.service_end in the pipeline logic. They need to have default values, or else it will crash if the Terra App doesn't define service_start and service_end in its own defaults.

WIP: Waiting on PR #73, because I needed one branch to use in Terra 3D.