### PR TITLE
WIP: Default overwrite

### DIFF
--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -383,6 +383,8 @@ global_templates = [
         # 'start_time': datetime.now(), # Not json serializable yet
         'uuid': terra_uuid
       },
+      "service_start": None,
+      "service_end": None,
       'settings_dir': settings_dir,
       'status_file': status_file,
       'processing_dir': processing_dir,

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -153,6 +153,7 @@ from logging.handlers import DEFAULT_TCP_LOGGING_PORT
 from inspect import isfunction
 from functools import wraps
 from json import JSONEncoder
+import multiprocessing
 import socket
 import platform
 import warnings
@@ -366,6 +367,7 @@ global_templates = [
         }
       },
       "executor": {
+        "num_workers": multiprocessing.cpu_count(),
         "type": "ProcessPoolExecutor",
         'volume_map': []
       },

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -383,6 +383,7 @@ global_templates = [
         # 'start_time': datetime.now(), # Not json serializable yet
         'uuid': terra_uuid
       },
+      "overwrite": False,
       "service_start": None,
       "service_end": None,
       'settings_dir': settings_dir,


### PR DESCRIPTION
Add overwrite = False to default settings. Overwrite is set to True in compute.base when resuming a service. In order to reliably use this setting, it needs to have a default value.

WIP: Waiting on PR #73 and #74, because I need one branch to use in Terra 3D.