### PR TITLE
Default service start / end

### DIFF
--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -383,6 +383,8 @@ global_templates = [
         # 'start_time': datetime.now(), # Not json serializable yet
         'uuid': terra_uuid
       },
+      'service_start': None,
+      'service_end': None,
       'settings_dir': settings_dir,
       'status_file': status_file,
       'processing_dir': processing_dir,


### PR DESCRIPTION
workflow.py references settings.service_start and settings.service_end in the pipeline logic. They need to have default values, or else it will crash if the Terra App doesn't define service_start and service_end in its own defaults.