### PR TITLE
Default overwrite setting

### DIFF
--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -383,6 +383,7 @@ global_templates = [
         # 'start_time': datetime.now(), # Not json serializable yet
         'uuid': terra_uuid
       },
+      'overwrite': False,
       'service_start': None,
       'service_end': None,
       'settings_dir': settings_dir,


### PR DESCRIPTION
Add overwrite = False to default settings. Overwrite is set to True in compute.base when resuming a service. In order to reliably use this setting in apps, it needs to have a default value.