### PR TITLE
default compose_files

### DIFF
--- a/terra/compute/docker.py
+++ b/terra/compute/docker.py
@@ -153,3 +153,12 @@ class Service(ContainerService):
   '''
   Base docker service class
   '''
+
+  def __init__(self):
+    super().__init__()
+
+    # default docker-compose file (if file exists)
+    compose_file = os.path.join(self.env['TERRA_APP_DIR'],
+                                'docker-compose.yml')
+    if os.path.isfile(compose_file):
+      self.compose_files = [compose_file]

--- a/terra/compute/singularity.py
+++ b/terra/compute/singularity.py
@@ -103,5 +103,14 @@ class Compute(BaseCompute):
 
 class Service(ContainerService):
   '''
-  Base docker service class
+  Base singularity service class
   '''
+
+  def __init__(self):
+    super().__init__()
+
+    # default compose file (if file exists)
+    compose_file = os.path.join(self.env['TERRA_APP_DIR'],
+                                'singular-compose.env')
+    if os.path.isfile(compose_file):
+      self.compose_files = [compose_file]


### PR DESCRIPTION
Add default `compose_files` for docker and singularity services, should expected file exist.

- Default docker service `compose_file` is `$TERRA_APP_DIR/docker-compose.yml`
- Default singularity service `compose_file` is `$TERRA_APP_DIR/singular-compose.env`

Users may still override these default files as they see fit.
