### PR TITLE
default compose_service_name 

### DIFF
--- a/terra.env
+++ b/terra.env
@@ -1,5 +1,6 @@
 JUST_PROJECT_PREFIX=TERRA
 JUST_VERSION="0.2.2+1dev"
+source "${VSI_COMMON_DIR}/linux/python_tools.bsh"
 
 if [[ -z "${TERRA_CWD+set}" ]]; then
   TERRA_CWD="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"

--- a/terra.env
+++ b/terra.env
@@ -33,6 +33,7 @@ fi
 
 # Register this app with Terra
 TERRA_APP_PREFIXES+=(TERRA)
+array_to_python_ast_list_of_strings TERRA_APP_PREFIXES_AST "${TERRA_APP_PREFIXES[@]}"
 : ${TERRA_JUST_SETTINGS=${BASH_SOURCE[0]}}
 set_array_default TERRA_APPS terra.tests.demo
 

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -59,7 +59,6 @@ class BaseService:
     '''
     return ast.literal_eval(self.env[key])
 
-
   def _validate_volume(self, local, remote,
                        check_remote=True,
                        local_must_exist=False):

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -1,3 +1,4 @@
+import ast
 import os
 import time
 import atexit
@@ -36,6 +37,28 @@ class BaseService:
     self.env = os.environ.copy()
     self.volumes = []
     ''' A copy of the processes environment variables local to a service '''
+
+  def _env_array(self, key):
+    '''
+    Recover array environment variables
+
+    For example, define the following in ``terra.env``
+
+    .. code-block:: bash
+
+        SOMETHING=( "hello" "there" )
+        array_to_python_ast_list_of_strings SOMETHING_AST "${SOMETHING[@]}"
+
+    Services can recover the environment variable as a python compatible
+    array via
+
+    .. code-block:: python
+
+        self._env_array('SOMETHING_AST')
+
+    '''
+    return ast.literal_eval(self.env[key])
+
 
   def _validate_volume(self, local, remote,
                        check_remote=True,

--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -27,6 +27,12 @@ class ContainerService(BaseService):
     self.container_platform = 'linux'
     self.extra_compose_files = []
 
+    # default compose_service_name
+    app_prefixes = self._env_array('TERRA_APP_PREFIXES_AST')
+    env_key = f"{app_prefixes[0]}_COMPOSE_SERVICE_RUNNER"
+    if env_key in self.env:
+      self.compose_service_name = env_key
+
   def pre_run(self):
     # Need to run Base's pre_run first, so it has a chance to update settings
     # for special executors, etc...

--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -30,8 +30,7 @@ class ContainerService(BaseService):
     # default compose_service_name
     app_prefixes = self._env_array('TERRA_APP_PREFIXES_AST')
     env_key = f"{app_prefixes[0]}_COMPOSE_SERVICE_RUNNER"
-    if env_key in self.env:
-      self.compose_service_name = env_key
+    self.compose_service_name = self.env.get(env_key)
 
   def pre_run(self):
     # Need to run Base's pre_run first, so it has a chance to update settings


### PR DESCRIPTION
Define the default container service `compose_service_name` as `${TERRA_APP_PREFIXES[0]}_COMPOSE_SERVICE_RUNNER` (as long as that environment variable exists).  This additionally adds the `_env_array` function to the base service, allowing services to more easily recover python compatible arrays from bash arrays encoded with `array_to_python_ast_list_of_strings`.