### PR TITLE
Improve experience with default settings.

### DIFF
--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -367,7 +367,7 @@ global_templates = [
         }
       },
       "executor": {
-        "num_workers": multiprocessing.cpu_count(),
+        "num_workers": multiprocessing.cpu_count() - 1,
         "type": "ProcessPoolExecutor",
         'volume_map': []
       },


### PR DESCRIPTION
The Terra controller already takes up one process. Account for that in the default number of processes you spawn for tasks. Minimize memory thrashing!