### PR TITLE
Pyinstaller celery

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -435,7 +435,7 @@ function terra_caseify()
 
     terra_pyinstaller) # Deploy terra using pyinstaller
       if ! Terra_Pipenv run sh -c "command -v pyinstaller" &> /dev/null; then
-        justify terra pipenv run pip install pyinstaller
+        justify terra pipenv sync --dev
       fi
       local indirect
       local app_prefix
@@ -498,13 +498,17 @@ function terra_caseify()
     #   ;;
 
     terra_makeself) # Create terra makeself, then append to it
-      justify makeself just-project
-      local terra_rel="$(relative_path "${TERRA_CWD}" .)" # Does not start with ./
+      local include_unit_tests
+      parse_args extra_args --tests include_unit_tests -- ${@+"${@}"}
+      local tests_args=()
+      if [ "${include_unit_tests}" != "0" ]; then
+        tests_args=(--tests)
+      fi
 
-      local JUST_SETTINGS=("${JUST_PATH_ESC}/src/terra.env")
+      local tar_extra="--exclude=./docs --exclude=./external --exclude ./terra"
 
-      justify makeself add-files "${TERRA_CWD}" \
-        "--show-transformed --transform s|^\./|./${terra_rel}/| --exclude=.git --exclude=./docs --exclude=./external --exclude=./*.secret --exclude=./build --exclude=*.egg-info --exclude test_*.py --exclude ./terra"
+      justify makeself just-project ${tests_args[@]+"${tests_args[@]}"}
+      justify makeself add-git-files "${TERRA_CWD}" "${tar_extra}"
       ;;
 
     ### Other ###

--- a/Pipfile
+++ b/Pipfile
@@ -13,13 +13,17 @@ flake8 = "*"
 pylint = "*"
 ipykernel = "*"
 coverage = "==5.0a5" # I need a prerelease, change to * after 5 is released
+pyinstaller = "*"
+# pyinstaller dependencies: not picked up my pipenv
+pefile = {version = ">= 2017.8.1", markers = "sys_platform == 'win32'"}
+pywin32-ctypes = {version = ">= 0.2.0", markers = "sys_platform == 'win32'"}
+macholib = {version = ">= 1.8", markers = "sys_platform == 'darwin'"}
 
 [packages]
 terra = {path = ".",editable = true}
 vsi-common = {editable = true,path = "./external/vsi_common"}
-# Repeat this dependencies possibly due to a bug
+# Repeat this dependencies possibly due to an editable bug
 jstyleson = "*"
-envcontext = "*"
 celery = {extras = ["redis"], version = "*"}
 flower = "*"
 pyyaml = "*"
@@ -27,7 +31,10 @@ pyyaml = "*"
 # docker and/or docker-compose are not handling win32-specific packages correctly
 # e.g., https://github.com/docker/compose/pull/6848/files
 # define these win32 packages directly to pipfile as workaround
+# docker-compose dependencies
 docker-compose = {markers = "sys_platform != 'win32'"}
 colorama = {version = ">=0.4, <1", markers = "sys_platform == 'win32'"}
+# docker dependencies
 pypiwin32 = {version = "==223", markers = "sys_platform == 'win32'"}
-pywin32 = {version = "==223", markers = "sys_platform == 'win32'"}
+# This doesn't work anymore, see: https://github.com/mhammond/pywin32/issues/1177
+# pywin32 = {version = "==223", markers = "sys_platform == 'win32'"}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "c8417a5b34b30799f0d6456075def32c10df825aace8166983688f3e999df37b"
+            "sha256": "1af91ce750248bfe979feaed4e1adf5f858cd7514694048a2b4c218a63efd84f"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -196,13 +196,6 @@
                 "sha256:49b3a825280bd66b3aa83585ef59c4a8c82f2c8a522dbe754a8bc8d08c85c491"
             ],
             "version": "==0.6.2"
-        },
-        "envcontext": {
-            "hashes": [
-                "sha256:a9df16ab42f1e02027aeb763b82b81fc857ae78b14101a515bec853ed4a5f4a8"
-            ],
-            "index": "pypi",
-            "version": "==2017.10.19.45"
         },
         "flower": {
             "hashes": [
@@ -611,6 +604,13 @@
             ],
             "version": "==0.7.0"
         },
+        "pefile": {
+            "hashes": [
+                "sha256:a5d6e8305c6b210849b47a6174ddf9c452b2888340b8177874b862ba6c207645"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==2019.4.18"
+        },
         "pexpect": {
             "hashes": [
                 "sha256:0b48a55dcb3c05f3329815901ea4fc1537514d6ba867a152b581d69ae3710937",
@@ -663,10 +663,17 @@
         },
         "pyinstaller": {
             "hashes": [
-                "sha256:3730fa80d088f8bb7084d32480eb87cbb4ddb64123363763cf8f2a1378c1c4b7"
+                "sha256:f5c0eeb2aa663cce9a5404292c0195011fa500a6501c873a466b2e8cad3c950c"
             ],
             "index": "pypi",
-            "version": "==3.6"
+            "version": "==4.2"
+        },
+        "pyinstaller-hooks-contrib": {
+            "hashes": [
+                "sha256:fa8280b79d8a2b267a2e43ff44f73b3e4a68fc8d205b8d34e8e06c960f7c2fcf",
+                "sha256:fc3290a2ca337d1d58c579c223201360bfe74caed6454eaf5a2550b77dbda45c"
+            ],
+            "version": "==2020.11"
         },
         "pylint": {
             "hashes": [
@@ -682,6 +689,14 @@
                 "sha256:75bb3f31ea686f1197762692a9ee6a7550b59fc6ca3a1f4b5d7e32fb98e2da2a"
             ],
             "version": "==2.8.1"
+        },
+        "pywin32-ctypes": {
+            "hashes": [
+                "sha256:24ffc3b341d457d48e8922352130cf2644024a4ff09762a2261fd34c36ee5942",
+                "sha256:9dc2d991b3479cc2df15930958b674a48a227d5361d413827a4cfd0b5876fc98"
+            ],
+            "markers": "sys_platform == 'win32'",
+            "version": "==0.2.0"
         },
         "pyzmq": {
             "hashes": [

--- a/freeze/hook-celery.py
+++ b/freeze/hook-celery.py
@@ -1,0 +1,2 @@
+
+hiddenimports = ['celery.fixups.django']

--- a/freeze/terra.spec
+++ b/freeze/terra.spec
@@ -5,6 +5,10 @@ import os
 import importlib
 from os import environ as env
 
+import warnings
+warnings.filterwarnings("ignore", category=ResourceWarning,
+                        module='pyinstaller', message="unclosed file")
+
 block_cipher = None
 
 # Pyinstaller removes this, but I want it. Put it back
@@ -43,8 +47,8 @@ for app_path, app_name in zip(app_paths, app_names):
                          pathex=[env['TERRA_CWD']],
                          binaries=[],
                          datas=[],
-                         hiddenimports=['pkg_resources.py2_warn'] \
-                                       + extra_hidden_imports,
+                         hiddenimports=extra_hidden_imports,
+                         # setuptools 45 - 49.0.0 needed pkg_resources.py2_warn
                          hookspath=hooks_dirs,
                          runtime_hooks=[],
                          excludes=[],

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,6 @@ setup(name="terra",
       install_requires=[
         "pyyaml",
         "jstyleson",
-        "envcontext",
         # I use signal and task from celery, no matter what
         "celery"
       ]

--- a/terra.env
+++ b/terra.env
@@ -173,7 +173,7 @@ source "${VSI_COMMON_DIR}/linux/just_files/docker_functions.bsh"
 
 : ${COMPOSE_FILE=${TERRA_CWD}/docker-compose-main.yml}
 
-# `pipenv sync` fails when seeded with pip versions 20.3.0 to 20.3.3.
+# `pipenv sync` fails when seeded with pip versions 20.3.0 and newer
 # The reported error involves mismatched metadata
 #    ERROR: Requested envcontext==2017.10.19.45 ...
 #    has different version in metadata: '2017.10.19'
@@ -182,5 +182,6 @@ source "${VSI_COMMON_DIR}/linux/just_files/docker_functions.bsh"
 # Pinning the seeded pip version to 20.2.4 resolves the issue. This is
 # accomplished via a VIRTUALENV_* environment variable as per:
 #   https://virtualenv.pypa.io/en/latest/cli_interface.html?highlight=environment%20variables#environment-variables
-# This pin can likely be eliminated with pip version 20.3.4
-: ${VIRTUALENV_PIP=20.2.4}
+# envcontext is no longer used, but incase another library has the
+# same problem uncomment the next line.
+# : ${VIRTUALENV_PIP=20.2.4}

--- a/terra.env
+++ b/terra.env
@@ -172,3 +172,15 @@ source "${VSI_COMMON_DIR}/linux/just_files/docker_functions.bsh"
 : ${COMPOSE_PROJECT_NAME=$(docker_compose_sanitize_project_name "${TERRA_CWD}" "${TERRA_USERNAME}")}
 
 : ${COMPOSE_FILE=${TERRA_CWD}/docker-compose-main.yml}
+
+# `pipenv sync` fails when seeded with pip versions 20.3.0 to 20.3.3.
+# The reported error involves mismatched metadata
+#    ERROR: Requested envcontext==2017.10.19.45 ...
+#    has different version in metadata: '2017.10.19'
+# This error appears to be caused by a new pip resolver introduced in pip 20.3
+#    https://github.com/pypa/pip/issues/9203
+# Pinning the seeded pip version to 20.2.4 resolves the issue. This is
+# accomplished via a VIRTUALENV_* environment variable as per:
+#   https://virtualenv.pypa.io/en/latest/cli_interface.html?highlight=environment%20variables#environment-variables
+# This pin can likely be eliminated with pip version 20.3.4
+: ${VIRTUALENV_PIP=20.2.4}

--- a/terra.env
+++ b/terra.env
@@ -82,7 +82,7 @@ fi
 # The file name used to store the password locally. Default: ``redis_password.secret``. If the file does not exist in ``redis_secret`` mode, than it is generated with a random password. This secret file should not be added to the your git repository; ``*.secret`` files are in the ``.gitignore`` file for this reason.
 #**
 if [ "${JUST_RODEO-}" = "1" ]; then
-  : ${TERRA_REDIS_SECRET_FILE=${USER_PWD}/redis_password.secret}
+  : ${TERRA_REDIS_SECRET_FILE=${ARCHIVE_DIR}/redis_password.secret}
 else
   : ${TERRA_REDIS_SECRET_FILE=${TERRA_CWD}/redis_password.secret}
 fi
@@ -143,7 +143,7 @@ fi
 : ${TERRA_REDIS_COMMANDER_PORT_DOCKER=4567}
 : ${TERRA_REDIS_COMMANDER_SECRET=redis_commander_secret}
 if [ "${JUST_RODEO-}" = "1" ]; then
-  : ${TERRA_REDIS_COMMANDER_SECRET_FILE=${USER_PWD}/redis_commander_password.secret}
+  : ${TERRA_REDIS_COMMANDER_SECRET_FILE=${ARCHIVE_DIR}/redis_commander_password.secret}
 else
   : ${TERRA_REDIS_COMMANDER_SECRET_FILE=${TERRA_CWD}/redis_commander_password.secret}
 fi

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -279,8 +279,9 @@ class _SetupTerraLogger():
     _warnings_showwarning = warnings.showwarning
     warnings.showwarning = handle_warning
 
-    # Enable warnings to default
-    warnings.simplefilter('default')
+    # Enable warnings to default, append this to the end of the filter list,
+    # so that any filters set elsewhere are not overridden by the behavior
+    warnings.simplefilter('default', append=True)
     # Disable known warnings that there's nothing to be done about.
     for module in ('yaml', 'celery.app.amqp'):
       warnings.filterwarnings("ignore",

--- a/terra/tests/test_core_settings.py
+++ b/terra/tests/test_core_settings.py
@@ -6,7 +6,7 @@ from unittest import mock
 from tempfile import TemporaryDirectory, NamedTemporaryFile
 import tempfile
 
-from envcontext import EnvironmentContext
+from vsi.vendored.envcontext import EnvironmentContext
 
 from .utils import TestCase, TestLoggerCase, TestLoggerConfigureCase
 from terra import settings


### PR DESCRIPTION
- Fixed bad RODEO paths in redis secret filenames
- Added `VIRTUALENV_PIP` to `terra.env` so that apps do not need to be responsible for this (Can be commented out in the future, due to the removal of `envcontext`)
- Removed `envcontext` and use a vendored version in VSI common instead. The `envcontext` `setup.py` file is bad, and has bad metadata that now causes it to fail to install correctly.
- Replaces the old makeself calls with the new improved makeself calls. Creates a more reliable frozen app
- Fixed how warnings are set up, so that previous warning filters are no longer wiped by accident. Previous, `terra.logging` had to be imported before setting up filters, this will no longer be true
- Celery workers were not working in a pyinstaller app due to hidden imports, this should be fixed now.
