### PR TITLE
broaden search for default compose files

### DIFF
--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -32,6 +32,17 @@ class ContainerService(BaseService):
     env_key = f"{app_prefixes[0]}_COMPOSE_SERVICE_RUNNER"
     self.compose_service_name = self.env.get(env_key)
 
+    # possible directories containing a compose file
+    # Note we don't rely just on TERRA_APP_DIR, as compose files will not
+    # be present in TERRA_APP_DIR in JUST_RODEO/makeself mode
+    compose_dirs = [
+        self.env.get('TERRA_APP_DIR'),
+        self.env.get(f"{app_prefixes[0]}_SOURCE_DIR"),
+    ]
+    compose_dirs = [os.path.abspath(d) for d in compose_dirs
+                    if d and os.path.isdir(d)]
+    self.compose_dirs = compose_dirs
+
   def pre_run(self):
     # Need to run Base's pre_run first, so it has a chance to update settings
     # for special executors, etc...

--- a/terra/compute/docker.py
+++ b/terra/compute/docker.py
@@ -158,7 +158,8 @@ class Service(ContainerService):
     super().__init__()
 
     # default docker-compose file (if file exists)
-    compose_file = os.path.join(self.env['TERRA_APP_DIR'],
-                                'docker-compose.yml')
-    if os.path.isfile(compose_file):
-      self.compose_files = [compose_file]
+    for compose_dir in self.compose_dirs:
+      compose_file = os.path.join(compose_dir, 'docker-compose.yml')
+      if os.path.isfile(compose_file):
+        self.compose_files = [compose_file]
+        break

--- a/terra/compute/singularity.py
+++ b/terra/compute/singularity.py
@@ -109,8 +109,9 @@ class Service(ContainerService):
   def __init__(self):
     super().__init__()
 
-    # default compose file (if file exists)
-    compose_file = os.path.join(self.env['TERRA_APP_DIR'],
-                                'singular-compose.env')
-    if os.path.isfile(compose_file):
-      self.compose_files = [compose_file]
+    # default singular-compose file (if file exists)
+    for compose_dir in self.compose_dirs:
+      compose_file = os.path.join(compose_dir, 'singular-compose.env')
+      if os.path.isfile(compose_file):
+        self.compose_files = [compose_file]
+        break


### PR DESCRIPTION
search multiple locations for default compose files. 

PR #85 introduced default compose files for docker/singularity services, checking only `TERRA_APP_DIR` for expected compose files.  However, in makeself/JUST_RODEO mode, `TERRA_APP_DIR` contains no compose files; compose files are instead in `${TERRA_APP_PREFIXES[0]}_SOURCE_DIR`, located at a temporary location on disk.  Search (in order) both directories for expected compose files, using the first discovered compose file as the default.

