### PR TITLE
settings.logging.log_file

### DIFF
--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -219,10 +219,9 @@ class BaseCompute:
   def configure_logger(sender, **kwargs):
     if settings.terra.zone == 'controller':
       # Setup log file for use in configure
-      if os.environ.get('TERRA_DISABLE_TERRA_LOG') != '1':
-        sender._log_file = os.path.join(
-            settings.processing_dir,
-            terra.logger._SetupTerraLogger.default_log_prefix)
+      if settings.logging.log_file:
+        os.makedirs(os.path.dirname(settings.logging.log_file), exist_ok=True)
+        sender._log_file = settings.logging.log_file
       else:
         sender._log_file = os.devnull
       os.makedirs(settings.processing_dir, exist_ok=True)
@@ -275,10 +274,9 @@ class BaseCompute:
     # output stream
 
     if settings.terra.zone == 'controller':
-      if os.environ.get('TERRA_DISABLE_TERRA_LOG') != '1':
-        log_file = os.path.join(
-            settings.processing_dir,
-            terra.logger._SetupTerraLogger.default_log_prefix)
+      if settings.logging.log_file:
+        os.makedirs(os.path.dirname(settings.logging.log_file), exist_ok=True)
+        log_file = settings.logging.log_file
       else:
         log_file = os.devnull
 

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -310,6 +310,19 @@ def terra_uuid(self):
 
 
 @settings_property
+def log_file(self):
+  '''
+  The default :func:`settings_property` for the log_file.
+  The default is :func:`processing_dir/terra.log<processing_dir>`.
+  This log file is not used if ``TERRA_DISABLE_TERRA_LOG`` is true.
+  '''
+  if os.environ.get('TERRA_DISABLE_TERRA_LOG') != '1':
+    return os.path.join(self.processing_dir, 'terra_log')
+  else:
+    return None
+
+
+@settings_property
 def logging_hostname(self):
   '''
   A :func:`settings_property` for getting the hostname for logging.
@@ -364,7 +377,8 @@ global_templates = [
           "hostname": logging_hostname,
           "port": DEFAULT_TCP_LOGGING_PORT,
           "listen_address": logging_listen_address,
-        }
+        },
+        "log_file": log_file,
       },
       "executor": {
         "num_workers": multiprocessing.cpu_count(),

--- a/terra/executor/celery/executor.py
+++ b/terra/executor/celery/executor.py
@@ -29,7 +29,6 @@ from logging.handlers import SocketHandler
 from celery.signals import setup_logging
 
 from terra.executor.base import BaseFuture, BaseExecutor
-import terra
 from terra import settings
 from terra.logger import getLogger
 logger = getLogger(__name__)

--- a/terra/executor/celery/executor.py
+++ b/terra/executor/celery/executor.py
@@ -260,9 +260,9 @@ class CeleryExecutor(BaseExecutor):
       sender.main_log_handler = NullHandler()
     elif settings.terra.zone == 'task_controller':
       # Setup log file for use in configure
-      if os.environ.get('TERRA_DISABLE_TERRA_LOG') != '1':
-        sender._log_file = os.path.join(settings.processing_dir,
-                                        terra.logger._logs.default_log_prefix)
+      if settings.logging.log_file:
+        os.makedirs(os.path.dirname(settings.logging.log_file), exist_ok=True)
+        sender._log_file = settings.logging.log_file
       else:
         sender._log_file = os.devnull
       os.makedirs(settings.processing_dir, exist_ok=True)
@@ -297,9 +297,9 @@ class CeleryExecutor(BaseExecutor):
           sender.main_log_handler = NullHandler()
           sender.root_logger.addHandler(sender.main_log_handler)
     elif settings.terra.zone == 'task_controller':
-      if os.environ.get('TERRA_DISABLE_TERRA_LOG') != '1':
-        log_file = os.path.join(settings.processing_dir,
-                                terra.logger._logs.default_log_prefix)
+      if settings.logging.log_file:
+        os.makedirs(os.path.dirname(settings.logging.log_file), exist_ok=True)
+        log_file = settings.logging.log_file
       else:
         log_file = os.devnull
 

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -212,7 +212,6 @@ class _SetupTerraLogger():
                                         ' %(message)s')
   default_stderr_handler_level = logging.WARNING
   default_tmp_prefix = "terra_initial_tmp_"
-  default_log_prefix = "terra_log"
 
   def __init__(self):
     self._configured = False

--- a/terra/tests/test_logger.py
+++ b/terra/tests/test_logger.py
@@ -223,8 +223,7 @@ class TestLogger(TestLoggerConfigureCase):
 
   def test_configured_file(self):
     settings._setup()
-    log_filename = os.path.join(self.temp_dir.name,
-                                self._logs.default_log_prefix)
+    log_filename = os.path.join(self.temp_dir.name, "terra_log")
 
     log_handler = [
         h for h in self._logs.root_logger.handlers


### PR DESCRIPTION
add `settings.logging.log_file` to define log file location, defaulting to `<processing_dir>/terra_log`.  Allows users to easily control & discover log file location.  Note whenever the log file is initialized, we ensure the directory containing the log file exists.