### PR TITLE
_checkLevel and _disableDebug

### DIFF
--- a/terra/logger.py
+++ b/terra/logger.py
@@ -623,6 +623,31 @@ logging.setLoggerClass(Logger)
 logger = getLogger(__name__)
 
 
+def _checkLevel(settings):
+  '''
+  Translate ``settings.logging.level`` to integer.
+  '''
+  try:
+    log_level = settings.logging.level
+  except AttributeError:
+    return 0
+
+  if isinstance(log_level, str):
+    log_level = log_level.upper()
+  return logging._checkLevel(log_level)
+
+
+def _disableDebug(settings, package_names):
+  '''
+  Disable debug logging for specific packages when ``settings.logging.level``
+  is between ``DEBUG1`` and ``DEBUG3`` (e.g., only enable for ``DEBUG4``)
+  '''
+  log_level = _checkLevel(settings)
+  if DEBUG3 <= log_level and log_level <= DEBUG1:
+    for package_name in package_names:
+      getLogger(package_name).setLevel('INFO')
+
+
 def _setup_terra_logger():
   # Must be import signal after getLogger is defined... Currently this is
   # imported from logger. But if a custom getLogger is defined eventually, it

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -623,29 +623,36 @@ logging.setLoggerClass(Logger)
 logger = getLogger(__name__)
 
 
-def _checkLevel(settings):
+def _checkLevel(log_level):
   '''
-  Translate ``settings.logging.level`` to integer.
+  Translate ``log_level`` to integer.
   '''
-  try:
-    log_level = settings.logging.level
-  except AttributeError:
-    return 0
-
   if isinstance(log_level, str):
     log_level = log_level.upper()
   return logging._checkLevel(log_level)
 
 
-def _disableDebug(settings, package_names):
+def _demoteLevel(package_names, from_level=DEBUG1, to_level=DEBUG4):
   '''
-  Disable debug logging for specific packages when ``settings.logging.level``
-  is between ``DEBUG1`` and ``DEBUG3`` (e.g., only enable for ``DEBUG4``)
+  Demote logging level for specific packages, disabling ``from_level`` log
+  messages unless ``terra.settings.logging.level > to_level``.
+
+  Arguments
+  ---------
+  package_names : :obj:`list` of :obj:`str`
+    List of package names
+  from_level
+    Log level to be demoted, default ``DEBUG1``
+  to_level
+    New log level, default ``DEBUG4``
+
   '''
-  log_level = _checkLevel(settings)
-  if DEBUG3 <= log_level and log_level <= DEBUG1:
+  from terra import settings
+  log_level = _checkLevel(settings.logging.level)
+
+  if to_level < log_level and log_level <= from_level:
     for package_name in package_names:
-      getLogger(package_name).setLevel('INFO')
+      getLogger(package_name).setLevel(from_level + 1)
 
 
 def _setup_terra_logger():


### PR DESCRIPTION
new logger convenience functions:
- `_checkLevel` to return integer log level from settings, useful for log level comparison
- `_disableDebug` to disable debug logging for selected packages based on the settings log level, enabling spam log messages from other packages only at `DEBUG4` 