### PR TITLE
just terra celery

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -47,7 +47,6 @@ function Terra_Pipenv()
         return 1
       fi
     fi
-    echo "env PIPENV_PIPFILE="${TERRA_CWD}/Pipfile" pipenv ${@+"${@}"}"
     ${DRYRUN} env PIPENV_PIPFILE="${TERRA_CWD}/Pipfile" pipenv ${@+"${@}"} || return $?
   else
     Just-docker-compose -f "${TERRA_CWD}/docker-compose-main.yml" run ${TERRA_PIPENV_IMAGE-terra} pipenv ${@+"${@}"} || return $?

--- a/terra.env
+++ b/terra.env
@@ -156,14 +156,14 @@ fi
 #
 # Array of Celery queue names.  Defaults to the ``terra`` and ``celery`` queues (``celery`` is the default Celery queue name).
 #**
-set_array_default TERRA_CELERY_QUEUES celery
+set_array_default TERRA_CELERY_QUEUES terra celery
 
 #**
 # .. envvar:: TERRA_CELERY_INCLUDE
 #
 # Array of modules containing Celery tasks.
 #**
-set_array_default TERRA_CELERY_INCLUDE terra.tests.demo.tasks
+set_array_default TERRA_CELERY_INCLUDE terra.task terra.tests.demo.tasks
 
 # redis-commander configuration
 : ${TERRA_REDIS_COMMANDER_PORT=4567}

--- a/terra.env
+++ b/terra.env
@@ -147,9 +147,25 @@ fi
 #**
 # .. envvar:: TERRA_CELERY_WORKERS
 #
-# Number of concurrent workers to start when you start a celery worker. The default is unset, and defaults to ``nprocs``. This variable should not be set in your ``local.env`` file without using the ``: ${TERRA_CELERY_WORKERS=5}`` form instead of ``TERRA_CELERY_WORKERS=5``, as it is meant to be dynamically set and exported by other higher level scripts.
+# Number of concurrent workers to start when you start a celery worker.
 #**
+: ${TERRA_CELERY_WORKERS=1}
 
+#**
+# .. envvar:: TERRA_CELERY_QUEUES
+#
+# Array of Celery queue names.  Defaults to the ``terra`` and ``celery`` queues (``celery`` is the default Celery queue name).
+#**
+set_array_default TERRA_CELERY_QUEUES celery
+
+#**
+# .. envvar:: TERRA_CELERY_INCLUDE
+#
+# Array of modules containing Celery tasks.
+#**
+set_array_default TERRA_CELERY_INCLUDE terra.tests.demo.tasks
+
+# redis-commander configuration
 : ${TERRA_REDIS_COMMANDER_PORT=4567}
 : ${TERRA_REDIS_COMMANDER_PORT_DOCKER=4567}
 : ${TERRA_REDIS_COMMANDER_SECRET=redis_commander_password}

--- a/terra/executor/celery/__main__.py
+++ b/terra/executor/celery/__main__.py
@@ -2,6 +2,7 @@
 
 from os import environ as env
 from . import app
+import tempfile
 
 # Terra
 from terra import settings
@@ -13,7 +14,8 @@ def main():
       {
         'executor': {'type': 'CeleryExecutor'},
         'terra': {'zone': 'task_controller'},
-        'logging': {'level': 'NOTSET'}
+        'logging': {'level': 'NOTSET'},
+        'processing_dir': tempfile.mkdtemp(prefix="terra_celery_"),
       }
     )
 

--- a/terra/executor/celery/celeryconfig.py
+++ b/terra/executor/celery/celeryconfig.py
@@ -1,7 +1,6 @@
 #!/usr/bin/env python
 
 from os import environ as env
-import kombu
 
 from terra.logger import getLogger
 logger = getLogger(__name__)
@@ -10,7 +9,7 @@ logger = getLogger(__name__)
 # from terra.executor.celery.celeryconfig import *
 __all__ = ['password', 'broker_url', 'result_backend', 'task_serializer',
            'result_serializer', 'accept_content', 'result_accept_content',
-           'result_expires', 'include']
+           'result_expires']
 
 try:
   with open(env['TERRA_REDIS_SECRET_FILE'], 'r') as fid:

--- a/terra/executor/celery/celeryconfig.py
+++ b/terra/executor/celery/celeryconfig.py
@@ -1,6 +1,7 @@
 #!/usr/bin/env python
 
 from os import environ as env
+import kombu
 
 from terra.logger import getLogger
 logger = getLogger(__name__)
@@ -30,13 +31,17 @@ accept_content = ['json', 'pickle']
 result_accept_content = ['json', 'pickle']
 result_expires = 3600
 
-# App needs to define include
-include = []
-_include_env_var = env.get('TERRA_CELERY_INCLUDE', None)
-if _include_env_var:
-  import ast
-  include = ast.literal_eval(_include_env_var)
-include += type(include)(['terra.tests.demo.tasks'])
+# Each celery worker should define its own queues (-Q <queues>) and
+# task modules (-I <modules>) from the command line. For example,
+#
+# pipenv python -m terra.executor.celery \
+#   -A terra.executor.celery.app worker \
+#   -Q queue1,queue2 \
+#   -I A.module1,A.B.module2 \
+#   ...
+#
+# More info here:
+# https://docs.celeryproject.org/en/stable/reference/cli.html#celery-worker
 
 # This is how it was done in Voxel Globe, but some detail is missing
 # from kombu import Queue, Exchange

--- a/terra/task.py
+++ b/terra/task.py
@@ -15,7 +15,7 @@ import terra.compute.utils
 from terra.logger import getLogger
 logger = getLogger(__name__)
 
-__all__ = ['TerraTask', 'shared_task', 'run_app']
+__all__ = ['TerraTask', 'shared_task', 'subprocess']
 
 
 # Take the shared task decorator, and add some Terra defaults, so you don't

--- a/terra/tests/test_executor_celery.py
+++ b/terra/tests/test_executor_celery.py
@@ -38,11 +38,6 @@ class TestCeleryConfig(TestCase):
     import terra.executor.celery.celeryconfig as cc
     self.assertEqual(cc.password, 'hiya')
 
-  @mock.patch.dict(os.environ, TERRA_CELERY_INCLUDE='["foo", "bar"]')
-  def test_include(self):
-    import terra.executor.celery.celeryconfig as cc
-    self.assertEqual(cc.include, ['foo', 'bar', 'terra.tests.demo.tasks'])
-
 
 class MockAsyncResult:
   def __init__(self, id, fun):


### PR DESCRIPTION
`just terra celery` to run a terra celery worker.  `TERRA_CELERY_*` environment variables are now intended to configure the _terra_ celery worker (not celery workers for terra apps).  The celery queue and included modules are configured from the command line.

Terra apps are expected to provide their own environment variables (e.g., `TERRA_DSM_CELERY_*) and configure their own queues and included modules from the command line.

The new generic task `terra.task.subprocess` (in the celery queue `terra`) will allow celery to execute a shell command via `subprocess.run`.  Note this task will be run with the terra pipenv/virtualenv disabled.

