### PR TITLE
Update 2206

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -449,10 +449,9 @@ function terra_caseify()
       fi
       ;;
 
-    terra_newapp) # Generate a new terra app. $1 is application name in CamelCase \
-                  # (e.g GenerateCatGraph), and $2 is the python path (e.g. foobar.cat). \
-                  # Optional, add a --dir flag to specify the output director, or else . \
-                  # is used
+    terra_newapp) # Generate a new terra app. Required: --AppName for the application name \
+                  # in CamelCase (e.g GenerateCatGraph), --module.path for the module path \
+                  # (e.g. foobar.cat). See --help for more information.
       justify terra pipenv run python -m terra.utils.new ${@+"${@}"}
       extra_args="${#}"
       ;;

--- a/Justfile
+++ b/Justfile
@@ -449,6 +449,14 @@ function terra_caseify()
       fi
       ;;
 
+    terra_newapp) # Generate a new terra app. $1 is application name in CamelCase \
+                  # (e.g GenerateCatGraph), and $2 is the python path (e.g. foobar.cat). \
+                  # Optional, add a --dir flag to specify the output director, or else . \
+                  # is used
+      justify terra pipenv run python -m terra.utils.new ${@+"${@}"}
+      extra_args="${#}"
+      ;;
+
     terra_pipenv) # Run pipenv commands in Terra's pipenv container. Useful for \
                   # installing/updating pipenv packages into terra
       TERRA_PIPENV_IMAGE=terra_pipenv Terra_Pipenv ${@+"${@}"}

--- a/terra/compute/docker.py
+++ b/terra/compute/docker.py
@@ -77,8 +77,11 @@ class Compute(BaseCompute):
       tty_args = ('-T')
 
     pid = just("--wrap", "Just-docker-compose",
-               *sum([['-f', cf] for cf in service_info.compose_files], []),
-               'run', *tty_args, service_info.compose_service_name,
+               *sum([['--file', cf] for cf in service_info.compose_files], []),
+               'run', *tty_args,
+               '--env', 'TERRA_SETTINGS_FILE='
+                        f'{service_info.env["TERRA_SETTINGS_FILE"]}',
+               service_info.compose_service_name,
                *service_info.command + extra_arguments,
                **optional_args,
                env=service_info.env)

--- a/terra/compute/docker.py
+++ b/terra/compute/docker.py
@@ -98,7 +98,7 @@ class Compute(BaseCompute):
     optional_args['justfile'] = getattr(service_info, 'justfile', None)
 
     args = ["--wrap", "Just-docker-compose"] + \
-        sum([['-f', cf] for cf in service_info.compose_files], []) + \
+        sum([['--file', cf] for cf in service_info.compose_files], []) + \
         ['config']
 
     pid = just(*args, stdout=PIPE,

--- a/terra/compute/docker.py
+++ b/terra/compute/docker.py
@@ -165,11 +165,4 @@ class Service(ContainerService):
   Base docker service class
   '''
 
-  def __init__(self):
-    super().__init__()
-
-    # default docker-compose file (if file exists)
-    compose_file = os.path.join(self.env['TERRA_APP_DIR'],
-                                'docker-compose.yml')
-    if os.path.isfile(compose_file):
-      self.compose_files = [compose_file]
+  compose_files  = []

--- a/terra/compute/docker.py
+++ b/terra/compute/docker.py
@@ -165,4 +165,4 @@ class Service(ContainerService):
   Base docker service class
   '''
 
-  compose_files  = []
+  compose_files = []

--- a/terra/compute/docker.py
+++ b/terra/compute/docker.py
@@ -165,4 +165,11 @@ class Service(ContainerService):
   Base docker service class
   '''
 
-  compose_files = []
+  def __init__(self):
+    super().__init__()
+
+    # default docker-compose file (if file exists)
+    compose_file = os.path.join(self.env['TERRA_APP_DIR'],
+                                'docker-compose.yml')
+    if os.path.isfile(compose_file):
+      self.compose_files = [compose_file]

--- a/terra/compute/singularity.py
+++ b/terra/compute/singularity.py
@@ -109,11 +109,4 @@ class Service(ContainerService):
   Base singularity service class
   '''
 
-  def __init__(self):
-    super().__init__()
-
-    # default compose file (if file exists)
-    compose_file = os.path.join(self.env['TERRA_APP_DIR'],
-                                'singular-compose.env')
-    if os.path.isfile(compose_file):
-      self.compose_files = [compose_file]
+  compose_file = []

--- a/terra/compute/singularity.py
+++ b/terra/compute/singularity.py
@@ -25,9 +25,10 @@ class Compute(BaseCompute):
     '''
     pid = just("singular-compose",
                *sum([['--file', cf] for cf in service_info.compose_files], []),
-               'run', service_info.compose_service_name,
+               'run',
                '--env', 'TERRA_SETTINGS_FILE='
                         f'{service_info.env["TERRA_SETTINGS_FILE"]}',
+               service_info.compose_service_name,
                *service_info.command + extra_arguments,
                env=service_info.env)
 
@@ -43,7 +44,7 @@ class Compute(BaseCompute):
     optional_args['justfile'] = getattr(service_info, 'justfile', None)
 
     args = ["singular-compose"] + \
-        sum([['-f', cf] for cf in service_info.compose_files], []) + \
+        sum([['--file', cf] for cf in service_info.compose_files], []) + \
         ['config-null', service_info.compose_service_name]
 
     pid = just(*args, stdout=PIPE,

--- a/terra/compute/singularity.py
+++ b/terra/compute/singularity.py
@@ -24,8 +24,10 @@ class Compute(BaseCompute):
             {service_info.command}
     '''
     pid = just("singular-compose",
-               *sum([['-f', cf] for cf in service_info.compose_files], []),
+               *sum([['--file', cf] for cf in service_info.compose_files], []),
                'run', service_info.compose_service_name,
+               '--env', 'TERRA_SETTINGS_FILE='
+                        f'{service_info.env["TERRA_SETTINGS_FILE"]}',
                *service_info.command + extra_arguments,
                env=service_info.env)
 

--- a/terra/compute/singularity.py
+++ b/terra/compute/singularity.py
@@ -110,4 +110,11 @@ class Service(ContainerService):
   Base singularity service class
   '''
 
-  compose_file = []
+  def __init__(self):
+    super().__init__()
+
+    # default compose file (if file exists)
+    compose_file = os.path.join(self.env['TERRA_APP_DIR'],
+                                'singular-compose.env')
+    if os.path.isfile(compose_file):
+      self.compose_files = [compose_file]

--- a/terra/tests/test_compute_docker.py
+++ b/terra/tests/test_compute_docker.py
@@ -101,7 +101,9 @@ class TestDockerRun(TestComputeDockerCase):
                       '--env', 'TERRA_SETTINGS_FILE=/foo/bar',
                       'launch', 'ls'),
                      self.just_args)
-    self.assertEqual({'justfile': None, 'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'}},
+    self.assertEqual({'justfile': None,
+                      'env': {'BAR': 'FOO',
+                              'TERRA_SETTINGS_FILE': '/foo/bar'}},
                      self.just_kwargs)
 
     # Test a non-zero return value
@@ -139,7 +141,8 @@ class TestDockerConfig(TestComputeDockerCase):
                       'config'), self.just_args)
 
     self.assertEqual({'stdout': docker.PIPE, 'justfile': None,
-                      'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'}},
+                      'env': {'BAR': 'FOO',
+                              'TERRA_SETTINGS_FILE': '/foo/bar'}},
                      self.just_kwargs)
 
   def test_config_with_multiple_compose_files(self):
@@ -154,7 +157,8 @@ class TestDockerConfig(TestComputeDockerCase):
                       'config'),
                      self.just_args)
     self.assertEqual({'stdout': docker.PIPE, 'justfile': None,
-                      'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'}},
+                      'env': {'BAR': 'FOO',
+                              'TERRA_SETTINGS_FILE': '/foo/bar'}},
                      self.just_kwargs)
 
 

--- a/terra/tests/test_compute_docker.py
+++ b/terra/tests/test_compute_docker.py
@@ -69,7 +69,7 @@ class MockJustService:
   compose_files = ["file1"]
   compose_service_name = "launch"
   command = ["ls"]
-  env = {"BAR": "FOO"}
+  env = {"BAR": "FOO", "TERRA_SETTINGS_FILE": "/foo/bar"}
 
 
 class TestDockerRun(TestComputeDockerCase):
@@ -97,9 +97,11 @@ class TestDockerRun(TestComputeDockerCase):
     compute.run(MockJustService())
     # Run a docker service
     self.assertEqual(('--wrap', 'Just-docker-compose',
-                      '-f', 'file1', 'run', 'launch', 'ls'),
+                      '--file', 'file1', 'run',
+                      '--env', 'TERRA_SETTINGS_FILE=/foo/bar',
+                      'launch', 'ls'),
                      self.just_args)
-    self.assertEqual({'justfile': None, 'env': {'BAR': 'FOO'}},
+    self.assertEqual({'justfile': None, 'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'}},
                      self.just_kwargs)
 
     # Test a non-zero return value
@@ -133,11 +135,11 @@ class TestDockerConfig(TestComputeDockerCase):
     compute = docker.Compute()
 
     self.assertEqual(compute.config(MockJustService()), 'out')
-    self.assertEqual(('--wrap', 'Just-docker-compose', '-f', 'file1',
+    self.assertEqual(('--wrap', 'Just-docker-compose', '--file', 'file1',
                       'config'), self.just_args)
 
     self.assertEqual({'stdout': docker.PIPE, 'justfile': None,
-                      'env': {'BAR': 'FOO'}},
+                      'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'}},
                      self.just_kwargs)
 
   def test_config_with_multiple_compose_files(self):
@@ -147,12 +149,12 @@ class TestDockerConfig(TestComputeDockerCase):
                                                      'file2.yaml']
     self.assertEqual(compute.config_service(service),
                      'out')
-    self.assertEqual(('--wrap', 'Just-docker-compose', '-f', 'file1',
-                      '-f', 'file15.yml', '-f', 'file2.yaml',
+    self.assertEqual(('--wrap', 'Just-docker-compose', '--file', 'file1',
+                      '--file', 'file15.yml', '--file', 'file2.yaml',
                       'config'),
                      self.just_args)
     self.assertEqual({'stdout': docker.PIPE, 'justfile': None,
-                      'env': {'BAR': 'FOO'}},
+                      'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'}},
                      self.just_kwargs)
 
 

--- a/terra/tests/test_compute_singularity.py
+++ b/terra/tests/test_compute_singularity.py
@@ -52,7 +52,9 @@ class TestSingular(TestComputeSingularityCase):
                       '--env', 'TERRA_SETTINGS_FILE=/foo/bar',
                       'launch', 'ls'),
                      self.just_args)
-    self.assertEqual({'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'}}, self.just_kwargs)
+    self.assertEqual({'env': {'BAR': 'FOO',
+                              'TERRA_SETTINGS_FILE': '/foo/bar'}},
+                     self.just_kwargs)
 
     # Test a non-zero return value
     self.return_value = 1
@@ -68,10 +70,13 @@ class TestSingular(TestComputeSingularityCase):
     service.compose_files = service.compose_files + ['file_too', 'fileThree']
     compute.run(service)
     # Run a singularity service
-    self.assertEqual(('singular-compose', '--file', 'file1', '--file', 'file_too',
-                      '--file', 'fileThree', 'run', '--env', 'TERRA_SETTINGS_FILE=/foo/bar', 'launch', 'ls'),
+    self.assertEqual(('singular-compose', '--file', 'file1', '--file',
+                      'file_too', '--file', 'fileThree', 'run', '--env',
+                      'TERRA_SETTINGS_FILE=/foo/bar', 'launch', 'ls'),
                      self.just_args)
-    self.assertEqual({'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'}}, self.just_kwargs)
+    self.assertEqual({'env': {'BAR': 'FOO',
+                              'TERRA_SETTINGS_FILE': '/foo/bar'}},
+                     self.just_kwargs)
 
     # Test a non-zero return value
     self.return_value = 1
@@ -105,7 +110,8 @@ class TestSingularityConfig(TestComputeSingularityCase):
     self.assertEqual(('singular-compose', '--file', 'file1',
                       'config-null', 'launch'), self.just_args)
 
-    self.assertEqual({'stdout': singularity.PIPE, 'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'},
+    self.assertEqual({'stdout': singularity.PIPE,
+                      'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'},
                       'justfile': None},
                      self.just_kwargs)
 
@@ -119,7 +125,8 @@ class TestSingularityConfig(TestComputeSingularityCase):
                       '--file', 'file15.env', '--file', 'file2.env',
                       'config-null', 'launch'),
                      self.just_args)
-    self.assertEqual({'stdout': singularity.PIPE, 'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'},
+    self.assertEqual({'stdout': singularity.PIPE,
+                      'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'},
                       'justfile': None},
                      self.just_kwargs)
 

--- a/terra/tests/test_compute_singularity.py
+++ b/terra/tests/test_compute_singularity.py
@@ -26,7 +26,7 @@ class MockJustService:
     self.compose_files = ["file1"]
     self.compose_service_name = "launch"
     self.command = ["ls"]
-    self.env = {"BAR": "FOO"}
+    self.env = {"BAR": "FOO", 'TERRA_SETTINGS_FILE': '/foo/bar'}
 
 
 class TestSingular(TestComputeSingularityCase):
@@ -48,10 +48,11 @@ class TestSingular(TestComputeSingularityCase):
     # This part of the test looks fragile
     compute.run(MockJustService())
     # Run a singularity service
-    self.assertEqual(('singular-compose', '-f', 'file1', 'run', 'launch',
-                      'ls'),
+    self.assertEqual(('singular-compose', '--file', 'file1', 'run',
+                      '--env', 'TERRA_SETTINGS_FILE=/foo/bar',
+                      'launch', 'ls'),
                      self.just_args)
-    self.assertEqual({'env': {'BAR': 'FOO'}}, self.just_kwargs)
+    self.assertEqual({'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'}}, self.just_kwargs)
 
     # Test a non-zero return value
     self.return_value = 1
@@ -67,10 +68,10 @@ class TestSingular(TestComputeSingularityCase):
     service.compose_files = service.compose_files + ['file_too', 'fileThree']
     compute.run(service)
     # Run a singularity service
-    self.assertEqual(('singular-compose', '-f', 'file1', '-f', 'file_too',
-                      '-f', 'fileThree', 'run', 'launch', 'ls'),
+    self.assertEqual(('singular-compose', '--file', 'file1', '--file', 'file_too',
+                      '--file', 'fileThree', 'run', '--env', 'TERRA_SETTINGS_FILE=/foo/bar', 'launch', 'ls'),
                      self.just_args)
-    self.assertEqual({'env': {'BAR': 'FOO'}}, self.just_kwargs)
+    self.assertEqual({'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'}}, self.just_kwargs)
 
     # Test a non-zero return value
     self.return_value = 1
@@ -101,10 +102,10 @@ class TestSingularityConfig(TestComputeSingularityCase):
 
     self.assertEqual(compute.config(MockJustService()),
                      {'environment': {'foo': 'bar'}, 'stuff': ['boo', 'far']})
-    self.assertEqual(('singular-compose', '-f', 'file1',
+    self.assertEqual(('singular-compose', '--file', 'file1',
                       'config-null', 'launch'), self.just_args)
 
-    self.assertEqual({'stdout': singularity.PIPE, 'env': {'BAR': 'FOO'},
+    self.assertEqual({'stdout': singularity.PIPE, 'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'},
                       'justfile': None},
                      self.just_kwargs)
 
@@ -114,11 +115,11 @@ class TestSingularityConfig(TestComputeSingularityCase):
     service.compose_files = service.compose_files + ['file15.env', 'file2.env']
     self.assertEqual(compute.config_service(service),
                      {'environment': {'foo': 'bar'}, 'stuff': ['boo', 'far']})
-    self.assertEqual(('singular-compose', '-f', 'file1',
-                      '-f', 'file15.env', '-f', 'file2.env',
+    self.assertEqual(('singular-compose', '--file', 'file1',
+                      '--file', 'file15.env', '--file', 'file2.env',
                       'config-null', 'launch'),
                      self.just_args)
-    self.assertEqual({'stdout': singularity.PIPE, 'env': {'BAR': 'FOO'},
+    self.assertEqual({'stdout': singularity.PIPE, 'env': {'BAR': 'FOO', 'TERRA_SETTINGS_FILE': '/foo/bar'},
                       'justfile': None},
                      self.just_kwargs)
 

--- a/terra/utils/new.py
+++ b/terra/utils/new.py
@@ -1,0 +1,349 @@
+import argparse
+import os
+import ast
+from os import environ as env
+
+from terra.utils.cli import FullPaths, clean_path
+
+class CreateTerraApp:
+  def __init__(self, app_camel_name, python_path, camel_name, under_name,
+               dir_name,):
+    self.app_camel_name = app_camel_name
+    self.python_path = python_path
+    self.dir = dir_name
+
+    self.camel_name = camel_name
+    self.under_name = under_name
+
+    terra_apps = ast.literal_eval(env['TERRA_APP_PREFIXES_AST'])
+    self.app_prefix = terra_apps[0]
+
+  def generate_files(self):
+    os.makedirs(os.path.join(self.dir, 'service_runners'), exist_ok=True)
+    os.makedirs(os.path.join(self.dir, 'tasks'), exist_ok=True)
+    os.makedirs(os.path.join(self.dir, 'tests'), exist_ok=True)
+
+    for create_file in [self.init, self.cli,
+                        self.workflows,
+                        self.service_definitions,
+                        self.service_runners_init,
+                        self.service_runners,
+                        self.tasks_init,
+                        self.tasks]:
+      try:
+        create_file()
+      except FileExistsError as fee:
+        print(f'{fee.filename} already exists, skipping')
+
+  def init(self):
+    with open(os.path.join(self.dir, '__init__.py'), 'x') as fid:
+      fid.write('''# Example: You would disable warnings for this app here.
+
+#import logging
+#import warnings
+
+#from terra.logger import _demoteLevel, DEBUG1, DEBUG4
+#import terra.core.signals
+
+## suppress specific warnings from pvl
+#warnings.filterwarnings("ignore", category=PendingDeprecationWarning,
+#                        module='pvl', message=r".*pvl\.collections\.Units.*")
+#warnings.filterwarnings("ignore", category=ImportWarning,
+#                        module='pvl', message=r".*PVLMultiDict.*")
+
+#terra.core.signals.logger_configure.connect(
+#    lambda *args, **kwargs: _demoteLevel(('shapely.geos',), DEBUG1, DEBUG4),
+#    weak=False)
+''')
+
+  def cli(self):
+    with open(os.path.join(self.dir, '__main__.py'), 'x') as fid:
+      fid.write(f'''import os
+import sys
+from os import environ as env
+import glob
+
+from {self.python_path}.workflows import {self.camel_name}Workflow
+
+from terra import settings
+from terra.core.settings import settings_property
+from terra.logger import getLogger
+from terra.utils.cli import FullPaths, ArgumentParser
+
+logger = getLogger(__name__)
+
+def get_parser():
+  parser = ArgumentParser(description="{self.app_camel_name} Runner")
+  aa = parser.add_argument
+  aa('settings', type=str, help="JSON settings file", action=FullPaths)
+  return parser
+
+@settings_property
+def some_thing_dir(self):
+  return os.path.join(self.processing_dir, 'some_thing')
+
+{self.app_camel_name.lower()}_templates = [
+  (
+    {{}},
+    {{
+      "parameter_alpha": 1.2,
+      "service_dirs": {{
+        "{self.under_name}_dir": some_thing_dir,
+      }}
+    }}
+  )
+]
+
+def main(args=None):
+  args = get_parser().parse_args(args)
+  env['TERRA_SETTINGS_FILE'] = args.settings
+  settings.add_templates({self.app_camel_name.lower()}_templates)
+
+  {self.app_camel_name.lower()} = {self.camel_name}Workflow()
+  {self.app_camel_name.lower()}.run()
+
+
+if __name__ == '__main__':
+  main()
+''')
+
+  def workflows(self):
+    with open(os.path.join(self.dir, 'workflows.py'), 'x') as fid:
+      fid.write(f'''from terra import settings
+from terra.compute import compute
+from terra.utils.workflow import resumable
+from terra.workflow import PipelineWorkflow
+from terra.logger import getLogger
+logger = getLogger(__name__)
+
+
+class {self.camel_name}Workflow(PipelineWorkflow):
+  def __init__(self):
+    services = [self.{self.camel_name}]
+
+    # if settings.parameter_alpha > 2:
+    #   services += [self.foobar]
+
+    self.pipeline = [*services]
+
+  @resumable
+  def {self.camel_name}(self):
+    compute.run('{self.python_path}.service_definitions.{self.camel_name}')
+''')
+
+  def service_definitions(self):
+    source_dir_docker = env[self.app_prefix + '_SOURCE_DIR_DOCKER']
+
+    with open(os.path.join(self.dir, 'service_definitions.py'), 'x') as fid:
+      fid.write(f'''from os import environ as env
+import os
+import posixpath
+
+# Terra settings
+from terra import settings
+
+# Terra compute architectures
+from terra.compute.virtualenv import (
+  Service as VenvService,
+  Compute as VenvCompute
+)
+from terra.compute.docker import (
+  Service as DockerService,
+  Compute as DockerCompute
+)
+from terra.compute.singularity import (
+  Service as SingularityService,
+  Compute as SingularityCompute
+)
+
+# Terra base service definition
+from terra.compute.base import BaseService
+from terra.compute.container import ContainerService
+
+# Terra logger
+from terra.logger import getLogger
+logger = getLogger(__name__)
+
+
+###############################################################################
+#                              COMMON SERVICES                                #
+###############################################################################
+
+{self.app_camel_name.lower()}_mount_points = {{
+
+    # current processing & service directory
+    "processing_dir": "/processing",
+
+    "image_dir": "/image",
+
+    # service directories
+    "{self.under_name}_dir": "/{self.app_camel_name.lower()}/some_thing",
+}}
+
+
+class {self.app_camel_name}BaseService(BaseService):
+  justfile = os.path.join(env.get('{self.app_prefix}_SOURCE_DIR', '{source_dir_docker}'), 'Justfile')
+
+  def pre_run(self):
+    self.service_dir = getattr(settings.service_dirs, self.service_dir_key)
+
+    # self.add_volume(self.service_dir, {self.app_camel_name.lower()}_mount_points[self.service_dir_key])
+
+    super().pre_run()
+
+
+class {self.app_camel_name}VenvService({self.app_camel_name}BaseService, VenvService):
+  pass
+
+
+class {self.app_camel_name}ContainerService({self.app_camel_name}BaseService, ContainerService):
+  compose_service_name = env['{self.app_prefix}_COMPOSE_SERVICE_RUNNER']
+
+
+class {self.app_camel_name}DockerService({self.app_camel_name}ContainerService, DockerService):
+  def __init__(self):
+    super().__init__()
+
+    # default docker-compose files
+    self.compose_files = [
+        os.path.join(env['{self.app_prefix}_SOURCE_DIR'], 'docker-compose.yml'),
+    ]
+
+
+class {self.app_camel_name}SingularityService({self.app_camel_name}ContainerService, SingularityService):
+  def __init__(self):
+    super().__init__()
+
+    # default singular-compose files
+    self.compose_files = [
+        os.path.join(env['{self.app_prefix}_SOURCE_DIR'], 'singular-compose.env'),
+    ]
+
+
+###############################################################################
+#                            Some Service                                     #
+###############################################################################
+class {self.camel_name}({self.app_camel_name}BaseService):
+  service_dir_key = '{self.under_name}_dir'
+  command = ['python', '-m', '{self.python_path}.service_runners.{self.under_name}']
+
+
+class {self.camel_name}_container({self.camel_name},
+                            {self.app_camel_name}ContainerService):
+  def __init__(self):
+    super().__init__()
+
+    # self.add_volume(settings.image_dir,
+    #                 {self.app_camel_name.lower()}_mount_points['image_dir'], 'ro')
+
+
+@VenvCompute.register({self.camel_name})
+class {self.camel_name}_Venv({self.camel_name}, {self.app_camel_name}VenvService):
+  pass
+
+
+@DockerCompute.register({self.camel_name})
+class {self.camel_name}_docker({self.camel_name}_container,
+                         {self.app_camel_name}DockerService):
+  pass
+
+
+@SingularityCompute.register({self.camel_name})
+class {self.camel_name}_singular({self.camel_name}_container,
+                           {self.app_camel_name}SingularityService):
+  pass
+''')
+
+  def service_runners_init(self):
+    with open(os.path.join(self.dir, 'service_runners', '__init__.py'), 'x') as fid:
+      fid.write(f'')
+
+  def service_runners(self):
+    with open(os.path.join(self.dir, 'service_runners', f'{self.under_name}.py'), 'x') as fid:
+      fid.write(f'''import concurrent.futures
+
+from terra import settings
+from terra.executor import Executor
+
+from {self.python_path}.tasks.{self.under_name} import {self.under_name}_in_parallel
+
+from terra.logger import getLogger
+logger = getLogger(__name__)
+
+def yield_{self.under_name}_futures(executor, xs, ys):
+  for x in xs:
+    for y in ys:
+      future = executor.submit({self.under_name}_in_parallel, x=x, y=y)
+      yield (future, (x,y))
+
+def main():
+  # Actual algorithm goes here. Here's a parallelism example
+  logger.critical('test')
+  with Executor(max_workers=settings.executor.num_workers) as executor:
+    futures_to_task = {{future: task_id for future, task_id in yield_{self.under_name}_futures(executor, (1,2), (10, 20))}}
+
+    for future in concurrent.futures.as_completed(futures_to_task):
+      x,y = futures_to_task[future]
+      logger.info(f"{{x}} + {{y}} = {{future.result()}}")
+
+if __name__=='__main__':
+  main()
+''')
+
+  def tasks_init(self):
+    with open(os.path.join(self.dir, 'tasks', '__init__.py'), 'x') as fid:
+      fid.write(f'')
+
+  def tasks(self):
+    with open(os.path.join(self.dir, 'tasks', f'{self.under_name}.py'), 'x') as fid:
+      fid.write(f'''from terra.task import shared_task
+
+# Terra core
+from terra.logger import getLogger
+logger = getLogger(__name__)
+
+@shared_task
+def {self.under_name}_in_parallel(self, x, y):
+  return x+y
+''')
+
+
+def get_parser():
+  parser = argparse.ArgumentParser()
+  parser.add_argument(
+      '--AppName', type=str, dest='app_name', default='AppName',
+      help="Name of app to create a template for, should be CamelCase")
+  parser.add_argument(
+      '--python.path', type=str, dest='python_path', required=True,
+      help="The python path of the module you are setting up")
+  parser.add_argument('--dir', default=clean_path('.'), type=str, action=FullPaths,
+      help="The directory to create the template in. Defaults to the current director")
+  parser.add_argument('--name', default="do something", type=str,
+      help="String to generate the workflow/service/task name: e.g. 'calculate threshold'")
+  return parser
+
+def main(args=None):
+  args = get_parser().parse_args(args)
+  Name = args.name.title().replace(' ', '')
+  name = args.name.lower().replace(' ', '_')
+  create_terra_app = CreateTerraApp(args.app_name, args.python_path,
+                                    Name, name, args.dir)
+  create_terra_app.generate_files()
+
+  print('''Here's an example config file to use:
+
+{
+  "logging": {
+    "level": "DEBUG3"
+  },
+  "compute": {
+    "arch": "docker"
+  }
+}
+
+''')
+
+  print(f'Simply run: just run {args.python_path} that_config_file.json')
+
+if __name__ == '__main__':
+  main()

--- a/terra/utils/new.py
+++ b/terra/utils/new.py
@@ -5,6 +5,7 @@ from os import environ as env
 
 from terra.utils.cli import FullPaths, clean_path
 
+
 class CreateTerraApp:
   def __init__(self, app_camel_name, python_path, camel_name, under_name,
                dir_name,):
@@ -37,7 +38,7 @@ class CreateTerraApp:
 
   def init(self):
     with open(os.path.join(self.dir, '__init__.py'), 'x') as fid:
-      fid.write('''# Example: You would disable warnings for this app here.
+      fid.write(r'''# Example: You would disable warnings for this app here.
 
 #import logging
 #import warnings
@@ -105,7 +106,7 @@ def main(args=None):
 
 if __name__ == '__main__':
   main()
-''')
+''')  # noqa: E501
 
   def workflows(self):
     with open(os.path.join(self.dir, 'workflows.py'), 'x') as fid:
@@ -252,14 +253,16 @@ class {self.camel_name}_docker({self.camel_name}_container,
 class {self.camel_name}_singular({self.camel_name}_container,
                            {self.app_camel_name}SingularityService):
   pass
-''')
+''')  # noqa: E501
 
   def service_runners_init(self):
-    with open(os.path.join(self.dir, 'service_runners', '__init__.py'), 'x') as fid:
-      fid.write(f'')
+    with open(os.path.join(self.dir, 'service_runners',
+                           '__init__.py'), 'x') as fid:
+      fid.write('')
 
   def service_runners(self):
-    with open(os.path.join(self.dir, 'service_runners', f'{self.under_name}.py'), 'x') as fid:
+    with open(os.path.join(self.dir, 'service_runners',
+                           f'{self.under_name}.py'), 'x') as fid:
       fid.write(f'''import concurrent.futures
 
 from terra import settings
@@ -286,16 +289,17 @@ def main():
       x,y = futures_to_task[future]
       logger.info(f"{{x}} + {{y}} = {{future.result()}}")
 
-if __name__=='__main__':
+if __name__ == '__main__':
   main()
-''')
+''')  # noqa: E501
 
   def tasks_init(self):
     with open(os.path.join(self.dir, 'tasks', '__init__.py'), 'x') as fid:
-      fid.write(f'')
+      fid.write('')
 
   def tasks(self):
-    with open(os.path.join(self.dir, 'tasks', f'{self.under_name}.py'), 'x') as fid:
+    with open(os.path.join(self.dir, 'tasks', f'{self.under_name}.py'), 'x') \
+        as fid:
       fid.write(f'''from terra.task import shared_task
 
 # Terra core
@@ -305,22 +309,25 @@ logger = getLogger(__name__)
 @shared_task
 def {self.under_name}_in_parallel(self, x, y):
   return x+y
-''')
+''')  # noqa: E501
 
 
 def get_parser():
   parser = argparse.ArgumentParser()
-  parser.add_argument(
-      '--AppName', type=str, dest='app_name', default='AppName',
-      help="Name of app to create a template for, should be CamelCase")
-  parser.add_argument(
-      '--python.path', type=str, dest='python_path', required=True,
-      help="The python path of the module you are setting up")
-  parser.add_argument('--dir', default=clean_path('.'), type=str, action=FullPaths,
-      help="The directory to create the template in. Defaults to the current director")
+  parser.add_argument('--AppName', type=str, dest='app_name',
+                      default='AppName', help="Name of app to create a "
+                      "template for, should be CamelCase")
+  parser.add_argument('--python.path', type=str, dest='python_path',
+                      required=True, help="The python path of the module you "
+                      "are setting up")
+  parser.add_argument('--dir', default=clean_path('.'), type=str,
+                      action=FullPaths, help="The directory to create the "
+                      "template in. Defaults to the current directory")
   parser.add_argument('--name', default="do something", type=str,
-      help="String to generate the workflow/service/task name: e.g. 'calculate threshold'")
+                      help="String to generate the workflow/service/task name:"
+                      " e.g. 'calculate threshold'")
   return parser
+
 
 def main(args=None):
   args = get_parser().parse_args(args)
@@ -344,6 +351,7 @@ def main(args=None):
 ''')
 
   print(f'Simply run: just run {args.python_path} that_config_file.json')
+
 
 if __name__ == '__main__':
   main()

--- a/terra/workflow.py
+++ b/terra/workflow.py
@@ -1,4 +1,5 @@
 from terra import settings
+from terra.compute import compute
 from terra.core.exceptions import NoStackValueError
 from terra.logger import getLogger
 logger = getLogger(__name__)
@@ -13,7 +14,15 @@ class BaseWorkflow:
     pass
 
 
-class PipelineWorkflow:
+class SingleWorkflow(BaseWorkflow):
+  def __init__(self, service):
+    self.service = service
+
+  def run(self):
+    compute.run(self.service)
+
+
+class PipelineWorkflow(BaseWorkflow):
   '''
   A simple workflow that runs a set of services, serially.
 


### PR DESCRIPTION
- Added a new app generator for creating a working terra app right away.
- Added a "SingleWorkflow" for easy workflow creation.
- `TERRA_SETTINGS_FILE` can now be passed along to containers directly without relying on the compose file to do it for you. This should be backwards compatible with the compose file method.
- ~Remove the default compose files from the container services, so that inheriting can be simplified. This should be backwards compatible with the old inheritance pattern.~