### PR TITLE
Adds a common CLI argument (--set) to override settings

### DIFF
--- a/terra.env
+++ b/terra.env
@@ -124,10 +124,6 @@ fi
 #
 # Optional environment variable that, when set to ``1``, will keep the temporary config files generated for containers. For debug use.
 #
-# .. envvar:: TERRA_DISABLE_SETTINGS_DUMP
-#
-# Optional environment variable that, when set to ``1``, will disable the saving of ``settings.json`` files in the processing dir. This is particularly useful for test script or jupyter notebooks where you do not want to litter ``settings.json`` files everywhere. For debug use.
-#
 # .. envvar:: TERRA_DISABLE_TERRA_LOG
 #
 # Optional environment variable that, when set to ``1``, will disable the saving of the ``terra_log`` file in the processing dir. This is particularly useful for test script or jupyter notebooks where you do not want to litter ``terra_log`` files everywhere. For debug use.

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -224,7 +224,8 @@ class BaseCompute:
         sender._log_file = settings.logging.log_file
       else:
         sender._log_file = os.devnull
-      os.makedirs(settings.processing_dir, exist_ok=True)
+      if settings.processing_dir:
+        os.makedirs(settings.processing_dir, exist_ok=True)
       sender._log_file = open(sender._log_file, 'a')
       sender.main_log_handler = StreamHandler(stream=sender._log_file)
       sender.root_logger.addHandler(sender.main_log_handler)

--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -56,7 +56,7 @@ class ContainerService(BaseService):
     env_volume_index += 1
 
     # This directory is used for both locking and setting dump, so don't
-    # if TERRA_DISABLE_SETTINGS_DUMP here
+    # if settings.terra.disable_settings_dump here
     os.makedirs(settings.settings_dir, exist_ok=True)
     self.env[f'{self.env["JUST_PROJECT_PREFIX"]}_'
              f'VOLUME_{env_volume_index}'] = \

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -598,12 +598,12 @@ class LazySettings(LazyObject):
     """
     settings_file = os.environ.get(ENVIRONMENT_VARIABLE)
     if not settings_file:
-      desc = ("setting %s" % name) if name else "settings"
+      desc = (f"setting {name}") if name else "settings"
       raise ImproperlyConfigured(
-          "Requested %s, but settings are not configured. "
-          "You must either define the environment variable %s "
-          "or call settings.configure() before accessing settings." %
-          (desc, ENVIRONMENT_VARIABLE))
+          f"Requested {desc}, but settings are not configured. "
+          "You must either define the environment variable "
+          f"{ENVIRONMENT_VARIABLE} or call settings.configure() before "
+          "accessing settings.")
     # Store in global variable :-\
     config_file.filename = settings_file
     self.configure(json_load(settings_file))

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -229,7 +229,7 @@ def settings_dir(self):
   '''
   The default :func:`settings_property` for settings dumps as JSON files.
   The default is :func:`processing_dir/settings<processing_dir>`.
-  This directory is not used if ``TERRA_DISABLE_SETTINGS_DUMP`` is true.
+  This directory is not used if settings.terra.disable_settings_dump is true.
   '''
   return os.path.join(self.processing_dir, 'settings')
 
@@ -419,6 +419,7 @@ global_templates = [
       },
       'terra': {
         'config_file': config_file,
+        'disable_settings_dump': False,
         'lock_dir': lock_dir,
         # unlike other settings, this should NOT be overwritten by a
         # config.json file, there is currently nothing to prevent that

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -26,17 +26,17 @@ Designating the settings
 
 .. envvar:: TERRA_SETTINGS_FILE
 
-    When you run a Terra App, you have to tell it which settings you’re using.
+    When you run a Terra App, you have to tell it which settings you're using.
     Do this by using an environment variable, :envvar:`TERRA_SETTINGS_FILE`.
 
 Default settings
 ----------------
 
-A Terra settings file doesn’t have to define any settings if it doesn’t need
+A Terra settings file doesn't have to define any settings if it doesn't need
 to. Each setting has a sensible default value. These defaults live in
 :data:`global_templates`.
 
-Here’s the algorithm terra uses in compiling settings:
+Here's the algorithm terra uses in compiling settings:
 
 * Load settings from global_settings.py.
 * Load settings from the specified settings file, overriding the global
@@ -57,7 +57,7 @@ In your Terra apps, use settings by importing the object
     if settings.params.max_time > 15:
         # Do something
 
-Note that :data:`terra.settings` isn’t a module – it’s an object. So importing
+Note that :data:`terra.settings` isn't a module - it's an object. So importing
 individual settings is not possible:
 
 .. code-block: python
@@ -67,8 +67,8 @@ individual settings is not possible:
 Altering settings at runtime
 ----------------------------
 
-You shouldn’t alter settings in your applications at runtime. For example,
-don’t do this in an app:
+You shouldn't alter settings in your applications at runtime. For example,
+don't do this in an app:
 
 .. code-block:: python
 
@@ -87,7 +87,7 @@ Using settings without setting TERRA_SETTINGS_FILE
 
 In some cases, you might want to bypass the :envvar:`TERRA_SETTINGS_FILE`
 environment variable. For example, if you are writing a simple metadata parse
-app, you likely don’t want to have to set up an environment variable pointing
+app, you likely don't want to have to set up an environment variable pointing
 to a settings file for each file.
 
 In these cases, you can configure Terra's settings manually. Do this by
@@ -112,7 +112,7 @@ particular setting is not passed to
 later point, Terra will use the default setting value.
 
 Configuring Terra in this fashion is mostly necessary - and, indeed,
-recommended - when you’re using are running a trivial transient app in the
+recommended - when you're using are running a trivial transient app in the
 framework instead of a larger application.
 
 '''

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -642,6 +642,7 @@ class LazySettings(LazyObject):
       raise ImproperlyConfigured('Settings already configured.')
     logger.debug2('Pre settings configure')
     self._wrapped = Settings(*args, **kwargs)
+    self._wrapped.update(override_config)
 
     for pattern, settings in global_templates:
       if nested_in_dict(pattern, self._wrapped):
@@ -849,6 +850,7 @@ class Settings(ObjectDict):
     self.update(backup)
 
 
+override_config = {}
 settings = LazySettings()
 '''LazySettings: The setting object to use through out all of terra'''
 

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -71,6 +71,7 @@ import socketserver
 import struct
 import select
 import pickle
+import atexit
 
 import terra
 from terra.core.exceptions import (
@@ -253,6 +254,8 @@ class _SetupTerraLogger():
     self.tmp_handler.setFormatter(self.default_formatter)
     self.root_logger.addHandler(self.tmp_handler)
 
+    atexit.register(self.cleanup_temp)
+
     # setup Buffers to use for replay after configure
     self.preconfig_stderr_handler = \
         logging.handlers.MemoryHandler(capacity=1000)
@@ -417,6 +420,19 @@ class _SetupTerraLogger():
     terra.core.signals.logger_reconfigure.send(sender=self, **kwargs)
 
     self.set_level_and_formatter()
+
+  def cleanup_temp(self):
+    try:
+      # If the file exists and was not /dev/null
+      if self.tmp_file and self.tmp_file.name != os.devnull and \
+         os.path.exists(self.tmp_file.name):
+        if (not self.tmp_file.file.closed and self.tmp_file.tell() == 0) or \
+           (self.tmp_file.file.closed
+            and os.stat(self.tmp_file.name).st_size == 0):
+          # if the filesize is zero, delete it. No point in littering
+          os.unlink(self.tmp_file.name)
+    except AttributeError:
+      pass
 
 
 class TerraAddFilter(Filter):

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -360,7 +360,7 @@ class _SetupTerraLogger():
     self.root_logger.removeHandler(self.preconfig_main_log_handler)
     self.root_logger.removeHandler(self.tmp_handler)
 
-    if os.environ.get('TERRA_DISABLE_SETTINGS_DUMP') != '1':
+    if not settings.terra.disable_settings_dump:
       os.makedirs(settings.settings_dir, exist_ok=True)
       settings_dump = os.path.join(
           settings.settings_dir,

--- a/terra/tests/test_core_settings.py
+++ b/terra/tests/test_core_settings.py
@@ -14,7 +14,7 @@ from terra import settings
 from terra.core.exceptions import ImproperlyConfigured
 from terra.core.settings import (
   ObjectDict, settings_property, Settings, LazyObject, TerraJSONEncoder,
-  ExpandedString, LazySettings
+  ExpandedString, LazySettings, override_config
 )
 
 
@@ -659,9 +659,38 @@ class TestSettings(TestLoggerCase):
     self.assertDictEqual(pickled._wrapped, settings._wrapped)
     self.assertIsNot(pickled._wrapped, settings._wrapped)
 
+  @mock.patch('terra.core.settings.override_config',
+              # Nested
+              {"executor": {"num_workers": 12.1,
+                            "type": "ThreadPoolExecutor",
+                            # Value not set by global templates
+                            "foo": "bar",
+                            "unset": True},
+               # Check top level too
+               "resume": "yarp",
+               "foo": "bar",
+               # Nested that doesn't exist already
+               "a": {"b": {"c": 12}}})
+  def test_override_config(self):
+    # Make sure I include overrides that are setting that both are and aren't
+    # specified by the configure command
+    settings.configure({"executor": {"type": "DummyExecutor", "foo": "car"},
+                        "resume": "nope",
+                        "processing_dir": "/foo/bar"})
+    self.assertEqual(settings.resume, "yarp")
+    self.assertEqual(settings.executor.num_workers, 12.1)
+    self.assertEqual(settings.executor.type, "ThreadPoolExecutor")
+    self.assertEqual(settings.executor.foo, "bar")
+    self.assertEqual(settings.executor.unset, True)
+    self.assertEqual(settings.resume, "yarp")
+    self.assertEqual(settings.foo, "bar")
+    self.assertEqual(settings.processing_dir, "/foo/bar")
+    self.assertEqual(settings.compute.arch, "terra.compute.dummy")
+    self.assertEqual(settings.a.b.c, 12)
+
 
 class TestUnitTests(TestCase):
-  # Don't make this part of the TestSettings class
+  # Don't make this part of the TestSettings class, it's a TestLoggerCase
 
   # def test_fail(self):
   #   settings.configure({})
@@ -673,6 +702,13 @@ class TestUnitTests(TestCase):
             "initialized the settings. This side effect should be "
             "prevented by mocking out the settings._wrapped attribute. "
             "Otherwise unit tests can interfere with each other")
+
+  def last_test_override(self):
+    self.assertEqual(override_config, {},
+        msg="If you are seeing this, one of the other unit tests has "
+            "changed the value of override_config. This side effect should be "
+            "prevented by mocking out the override_config. Otherwise unit "
+            "tests can interfere with each other")
 
 
 class TestSettingsClass(TestCase):

--- a/terra/tests/test_utils_cli.py
+++ b/terra/tests/test_utils_cli.py
@@ -1,9 +1,11 @@
+from unittest import mock
 import argparse
 import os
 
-from terra.utils.cli import FullPaths, FullPathsAppend
+from terra.utils.cli import FullPaths, FullPathsAppend, OverrideAction
 from .utils import TestCase
 
+from terra.core.settings import override_config
 
 class TestFullPaths(TestCase):
   def test_full_paths(self):
@@ -24,3 +26,20 @@ class TestFullPaths(TestCase):
            os.path.join(os.path.expanduser('~'), 'home.txt'),
            os.path.join(os.getcwd(), 'bar.txt')]
     self.assertEqual(ans, args.foo)
+
+  @mock.patch.dict('terra.core.settings.override_config', {})
+  def test_override(self, over=None):
+    oa = OverrideAction(None, None)
+    oa(None, None, ['foo=bar'])
+    self.assertEqual(override_config, {'foo': 'bar'})
+
+    oa(None, None, ['foo=bar1', 'a.b.c=15'])
+    self.assertEqual(override_config,
+        {'foo': 'bar1',
+         'a': {'b': {'c': 15}}})
+
+    with self.assertRaises(argparse.ArgumentError) as cm:
+      oa(None, None, ['oops'])
+
+    self.assertTrue(cm.exception.message.startswith(
+        'There was no "=" found in setting '))


### PR DESCRIPTION
- Feature: Add `--set` as an argument that can be used to set one or more python arguments. Treated as a python literal so it can be any mixture of lists, tuples, dicts, string, ints, and floats. (ast literal eval). If that fails, it is treated as a literal string.
- Clean up: Automatically delete initial terra logs that are empty. This only clutters up the temp directory with empty files. The purpose of this file is to catch errors before terra configures, not to leave empty files behind. This often happens if terra is imported and never used.
- Change: Convert the environment variable `TERRA_DISABLE_SETTINGS_DUMP` into a terra setting. There is no reason for this to be an environment variable, and the less random untracked environment variables for controlling terra, the better.
- Bug fix: Only create processing dir when it has a set value
- Misc: Remove stray unicode
- Misc: convert some old style python strings to f-strings

The main feature here is the `--set` argument, it should support any combination needed with the least amount of surprising behavior:

(Note: the following examples assume you are using bash for your shell)

- `--set foo=bar` is equivalent `settings.foo="bar"`
- `--set foo=\"bar\"` is the equivalent `settings.foo="bar"` (the exact same)
- `--set 'foo="\"bar\""' is the equivalent to `settings.foo='"bar"'` 
- `--set a=1 b=2.2 c=\"3\" -- d=4` is the equivalent of:
  - `settings.a=1`
  - `settings.b=2.2`
  - `settings.c="3"`
  - d is not interprested by `--set`, no arguments are parsed pass `--` by argparse, 
- `--set x=5` is `settings.x=5`, so the integer 5
  - `--set x="5"` is the exact same thing in bash
- `--set x=\"5\"` would be `settings.x="5"`, the string 5
- `--set a.b.c=5+2` would be `settings.a.b.c="5+2"` so a nested setting, but a literal string
- `--set 'y=(1, "2", {"x": 7.5})'` would be `settings.y = (1, "2", {"x": 7.5})`, a complex expression
- `--set z=os.path.sep` would be `settings.z="os.path.sep"` a literal string
- `--set bad_actor=os.rmdir(os.path.sep)` would of course be a safe literal string too `settings.bad_actor="os.rmdir(os.path.sep)"`

Error cases:
- `--set a=1 something else` would error out because something does not have an `=` in it
  - `--set a=1 -- something else` will work
  - `--set=a=1 something else` will also work, since it tells --set that there's only one argument `a=1`
  - `--set a=1 --foo=bar something else` would actually work, because argparse knew to start parse `--set` once it encountered `--foo`