### PR TITLE
singularity TERRA_SETTINGS_FILE 

### DIFF
--- a/terra/tests/test_compute_singularity.py
+++ b/terra/tests/test_compute_singularity.py
@@ -71,7 +71,8 @@ class TestSingular(TestComputeSingularityCase):
     compute.run(service)
     # Run a singularity service
     self.assertEqual(('singular-compose', '--file', 'file1', '--file',
-                      'file_too', '--file', 'fileThree', 'run', 'launch', 'ls'),
+                      'file_too', '--file', 'fileThree', 'run',
+                      'launch', 'ls'),
                      self.just_args)
     self.assertEqual({'env': {'BAR': 'FOO',
                               'SINGULARITYENV_TERRA_SETTINGS_FILE': '/foo/bar',

--- a/terra/tests/test_compute_singularity.py
+++ b/terra/tests/test_compute_singularity.py
@@ -49,10 +49,10 @@ class TestSingular(TestComputeSingularityCase):
     compute.run(MockJustService())
     # Run a singularity service
     self.assertEqual(('singular-compose', '--file', 'file1', 'run',
-                      '--env', 'TERRA_SETTINGS_FILE=/foo/bar',
                       'launch', 'ls'),
                      self.just_args)
     self.assertEqual({'env': {'BAR': 'FOO',
+                              'SINGULARITYENV_TERRA_SETTINGS_FILE': '/foo/bar',
                               'TERRA_SETTINGS_FILE': '/foo/bar'}},
                      self.just_kwargs)
 
@@ -71,10 +71,10 @@ class TestSingular(TestComputeSingularityCase):
     compute.run(service)
     # Run a singularity service
     self.assertEqual(('singular-compose', '--file', 'file1', '--file',
-                      'file_too', '--file', 'fileThree', 'run', '--env',
-                      'TERRA_SETTINGS_FILE=/foo/bar', 'launch', 'ls'),
+                      'file_too', '--file', 'fileThree', 'run', 'launch', 'ls'),
                      self.just_args)
     self.assertEqual({'env': {'BAR': 'FOO',
+                              'SINGULARITYENV_TERRA_SETTINGS_FILE': '/foo/bar',
                               'TERRA_SETTINGS_FILE': '/foo/bar'}},
                      self.just_kwargs)
 


### PR DESCRIPTION
inject `TERRA_SETTINGS_FILE` into singularity environment using `SINGULARITYENV_*`
https://docs.sylabs.io/guides/3.7/user-guide/environment_and_metadata.html#environment-overview

We favor the `SINGULARITYENV_` method for compatibility with `just singular-compose` which currently requires the argument after `run` to be the service name.

Follow up to PR #134 

