### PR TITLE
Terra pipenv setup

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -38,7 +38,7 @@ function Terra_Pipenv()
 {
   local answer_continue="${answer_continue-}"
 
-  if [[ ${TERRA_LOCAL-} == 1 ]]; then
+  if [ "${TERRA_LOCAL-}" = "1" ]; then
     if [ -n "${VIRTUAL_ENV+set}" ] || [ -n "${CONDA_DEFAULT_ENV+set}" ]; then
       echo "Warning: You appear to be in a virtual/conda env" >&2
       echo "This can interfere with terra and cause unexpected consequences" >&2
@@ -79,7 +79,7 @@ function terra_caseify()
       else
         justify build recipes-auto "${TERRA_CWD}/docker/"*.Dockerfile
         Docker-compose -f "${TERRA_CWD}/docker-compose-main.yml" build
-        if [[ ${TERRA_LOCAL-} == 0 ]]; then
+        if [ "${TERRA_LOCAL-}" = "0" ]; then
           COMPOSE_FILE="${TERRA_CWD}/docker-compose-main.yml" justify docker-compose clean terra-venv
         fi
         justify terra build-services
@@ -136,7 +136,7 @@ function terra_caseify()
       # 2 is the exit code of an error in arg parsing
       # 62 for any other terra error
       local JUST_IGNORE_EXIT_CODES='2$|^62'
-      if [[ ${JUST_RODEO-} == 1 ]]; then
+      if [ "${JUST_RODEO-}" = "1" ]; then
         extra_args=$#
         local app_name="${1}"
         shift 1
@@ -158,7 +158,7 @@ function terra_caseify()
       ;;
 
     terra_run-nopipenv) # Run terra command not in pipenv
-      if [[ ${TERRA_LOCAL-} == 1 ]]; then
+      if [ "${TERRA_LOCAL-}" = "1" ]; then
         ${@+"${@}"}
       else
         Just-docker-compose -f "${TERRA_CWD}/docker-compose-main.yml" run ${terra_service_name-terra} nopipenv ${@+"${@}"} || rv=$?
@@ -170,7 +170,7 @@ function terra_caseify()
 
       # node name (including node location)
       local node_name
-      if [[ ${TERRA_LOCAL-} == 1 ]]; then
+      if [ "${TERRA_LOCAL-}" = "1" ]; then
         node_name="terra-local@%h"
       else
         node_name="terra-container@%h"
@@ -261,7 +261,7 @@ function terra_caseify()
       source "${VSI_COMMON_DIR}/linux/colors.bsh"
       echo "${YELLOW}Running ${GREEN}python ${YELLOW}Tests${NC}"
       JUST_IGNORE_EXIT_CODES=1
-      if [[ $# == 0 ]]; then
+      if [ "${#}" = "0" ]; then
         # Use bash -c So that TERRA_TERRA_DIR is evaluated correctly inside the environment
         Terra_Pipenv run env TERRA_UNITTEST=1 bash -c 'python -m unittest discover "${TERRA_TERRA_DIR}/terra"'
       else
@@ -312,7 +312,7 @@ function terra_caseify()
         touch "${TERRA_CWD}/.just_synced"
       fi
       justify git_submodule-update # For those users who don't remember!
-      if [[ ${TERRA_LOCAL-} == 0 ]]; then
+      if [ "${TERRA_LOCAL-}" = "0" ]; then
         COMPOSE_FILE="${TERRA_CWD}/docker-compose-main.yml" justify docker-compose clean terra-venv
         justify terra sync-pipenv
         justify terra build-services
@@ -471,7 +471,7 @@ function terra_caseify()
       [ "${answer_clean_all}" == "0" ] && return 1
       COMPOSE_FILE="${TERRA_CWD}/docker-compose-main.yml" justify docker-compose clean terra-venv
       COMPOSE_FILE="${TERRA_CWD}/docker-compose.yml" justify docker-compose clean terra-redis
-      if [[ ${TERRA_LOCAL-} == 1 ]]; then
+      if [ "${TERRA_LOCAL-}" = "1" ]; then
         Terra_Pipenv --rm
       fi
       ;;

--- a/Justfile
+++ b/Justfile
@@ -39,6 +39,12 @@ function Terra_Pipenv()
   local answer_continue="${answer_continue-}"
 
   if [ "${TERRA_LOCAL-}" = "1" ]; then
+    if ! command -v pipenv &> /dev/null; then
+      add_to_local=y justify terra setup --dir "${TERRA_CWD}/build/pipenv" --download
+      # since I want to continue without re-sourcing local.env
+      export PATH="${TERRA_CWD}/build/pipenv/bin:${PATH}"
+    fi
+
     if [ -n "${VIRTUAL_ENV+set}" ] || [ -n "${CONDA_DEFAULT_ENV+set}" ]; then
       echo "Warning: You appear to be in a virtual/conda env" >&2
       echo "This can interfere with terra and cause unexpected consequences" >&2
@@ -367,6 +373,8 @@ function terra_caseify()
       local conda_install
 
       : ${PYTHON_VERSION=3.7.13}
+      : ${PIPENV_VERSION=2023.4.29}
+      : ${VIRTUALENV_VERSION=20.23.0}
 
       parse_args extra_args --dir output_dir: --python python_exe: --conda conda_exe: --download download_conda --conda-install conda_install: -- ${@+"${@}"}
 

--- a/Justfile
+++ b/Justfile
@@ -361,7 +361,12 @@ function terra_caseify()
 
     terra_sync-pipenv) # Synchronize the local pipenv for terra. You normally \
                        # don't call this directly
-      TERRA_PIPENV_IMAGE=terra_pipenv Terra_Pipenv sync ${@+"${@}"}
+      if [ -z "${PYTHON_EXE+set}" ]; then
+        local PYTHON_EXE=$(command -v python)
+      fi
+      local pipenv_args=(--python "${PYTHON_EXE}")
+
+      TERRA_PIPENV_IMAGE=terra_pipenv Terra_Pipenv "${pipenv_args[@]}" sync ${@+"${@}"}
       extra_args=$#
       ;;
 

--- a/terra.env
+++ b/terra.env
@@ -22,7 +22,7 @@ fi
 #
 # By default, terra runs in a docker container. Since the docker compute type uses docker, in scenarios other than the docker socket and external docker sockets, piping the docker connection into a container can prove troublesome. For this reason, the terra master controller can also be run on the host.
 #
-# :envvar:`TERRA_LOCAL` defaults to 0, disabled. But can either be enabled in your ``local.env`` or by using the ``--local`` flag
+# :envvar:`TERRA_LOCAL` defaults to 1, run terra locally. But can either be enabled in your ``local.env`` or forced to ``1`` using the ``--local`` flag
 #**
 : ${TERRA_LOCAL=1}
 


### PR DESCRIPTION
Setting up pipenv on terra has been plagued with many corner cases of failure for a while. It always gets fixed by hand, and the problem is never really solved.

This is the first attempt to fix it. If `pipenv` is not detected, then it will automatically:

1. Download miniconda
2. Use miniconda to download python 3.7.13
3. Use python 3.7.13 to install pipenv 2023.4.29 and virtualenv 20.23.0
4. Use pipenv 2023.4.29 to create a python 3.7.13 virtualenv and sync to it

This should resolve most of the issue we are constantly running into