### PR TITLE
Memory leak

### DIFF
--- a/terra/executor/sync.py
+++ b/terra/executor/sync.py
@@ -1,4 +1,5 @@
 from threading import Lock
+from traceback import clear_frames
 
 from terra.executor.base import BaseExecutor, BaseFuture
 
@@ -30,6 +31,7 @@ class SyncExecutor(BaseExecutor):
       try:
         result = fn(*args, **kwargs)
       except BaseException as e:
+        clear_frames(e)
         f.set_exception(e)
       else:
         f.set_result(result)

--- a/terra/executor/sync.py
+++ b/terra/executor/sync.py
@@ -31,7 +31,7 @@ class SyncExecutor(BaseExecutor):
       try:
         result = fn(*args, **kwargs)
       except BaseException as e:
-        clear_frames(e)
+        clear_frames(e.__traceback__)
         f.set_exception(e)
       else:
         f.set_result(result)

--- a/terra/executor/thread.py
+++ b/terra/executor/thread.py
@@ -49,3 +49,4 @@ class ThreadPoolExecutor(concurrent.futures.ThreadPoolExecutor,
     future = super().submit(fn, *args, **kwargs)
     future.add_done_callback(auto_clear_exception_frames)
     return future
+  submit.__doc__ = ""


### PR DESCRIPTION
Finally tracked down a solution to the leak

C++ threw an exception which means the deconstructor for variables in `bsgm_prob_pairwise_dsm::process/compute_min_max_disparity_from_height` doesn't get called right away. Instead it stays on the heap for a while, meanwhile the python wrapper object for `bsgm_prob_pairwise_dsm` gets collected in a python exception traceback frame, keeping the ref count at one never allowing `bsgm_prob_pairwise_dsm` to be garbage collected. When the executor context ends, all this memory would have freed up, however if you run out of memory before that, it all fails.

The solution is to just clear the frames of the tracebacks, and the only universal method I could find to do that was by adding a callback function to the Future object.

This will unfortunately make attaching a post mortem debugging for an exception in a task  harder, But normal `set_trace`ing will still work as intended.