### PR TITLE
remove leading underscore from lock_counter member

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(name="terra",
         "jstyleson",
         # I use signal and task from celery, no matter what
         "celery",
-        "filelock"
+        "filelock>=3.12"
       ]
 )

--- a/terra/executor/resources.py
+++ b/terra/executor/resources.py
@@ -282,7 +282,7 @@ class Resource:
     if not self.is_locked:
       raise ValueError('Release called with no lock acquired')
 
-    if not force and self._local.lock._lock_counter > 1:
+    if not force and self._local.lock.lock_counter > 1:
       self._local.lock.release()
       return
 

--- a/terra/tests/test_executor_resources.py
+++ b/terra/tests/test_executor_resources.py
@@ -146,14 +146,14 @@ class TestResourceLock(TestResourceCase):
     self.assertFalse(test.is_locked)
     test.acquire()
     self.assertTrue(test.is_locked)
-    self.assertEqual(test._local.lock._lock_counter, 1)
+    self.assertEqual(test._local.lock.lock_counter, 1)
     test.acquire()
     self.assertTrue(test.is_locked)
-    self.assertEqual(test._local.lock._lock_counter, 2)
+    self.assertEqual(test._local.lock.lock_counter, 2)
 
     test.release()
     self.assertTrue(test.is_locked)
-    self.assertEqual(test._local.lock._lock_counter, 1)
+    self.assertEqual(test._local.lock.lock_counter, 1)
 
     test.release()
     self.assertFalse(test.is_locked)
@@ -190,7 +190,7 @@ class TestResourceLock(TestResourceCase):
     with resource as r2:
       with resource as r3:
         self.assertTrue(resource.is_locked)
-        self.assertEqual(resource._local.lock._lock_counter, 2)
+        self.assertEqual(resource._local.lock.lock_counter, 2)
       self.assertTrue(resource.is_locked)
     self.assertFalse(resource.is_locked)
 


### PR DESCRIPTION
I haven't yet figured out why this change is needed for me - Perhaps the API of the `filelock` library changed recently?  I have `filelock` version 3.12.0,  Python 3.10.11