### PR TITLE
best patch_volume

### DIFF
--- a/terra/tests/test_utils_path.py
+++ b/terra/tests/test_utils_path.py
@@ -26,7 +26,9 @@ class TestTranslateUtils(TestCase):
 
     # test data
     test_data = [
+        (('src', ), ('dst', )),
         (('src', 'abc'), ('dst', 'ABC')),
+        (('src', 'abc', 'def'), ('dst', 'ABC', 'DEF')),
         (('src', 'abc_output'), ('dst', 'OUTPUT')),
         (('src', 'def'), ('dst', 'DEF')),
         (('src', 'abc.json'), ('dst', 'ABC.json')),
@@ -64,6 +66,7 @@ class TestTranslateUtils(TestCase):
 
   def _test_patch_volume(self, container_platform):
     volume_map = self._create_volume_map(os.name, container_platform)
+    volume_map_rev = volume_map[::-1]
     host_os, container_os = self._os(os.name, container_platform)
 
     for host_vol, container_vol in volume_map:
@@ -80,6 +83,8 @@ class TestTranslateUtils(TestCase):
         host_item = host_os.join(host_vol, *item)
         container_item = container_os.join(container_vol, *item)
         result = utils.patch_volume(host_item, volume_map, container_platform)
+        self.assertEqual(result, container_item)
+        result = utils.patch_volume(host_item, volume_map_rev, container_platform)
         self.assertEqual(result, container_item)
 
   def test_patch_volume_linux(self):

--- a/terra/tests/test_utils_path.py
+++ b/terra/tests/test_utils_path.py
@@ -84,7 +84,8 @@ class TestTranslateUtils(TestCase):
         container_item = container_os.join(container_vol, *item)
         result = utils.patch_volume(host_item, volume_map, container_platform)
         self.assertEqual(result, container_item)
-        result = utils.patch_volume(host_item, volume_map_rev, container_platform)
+        result = utils.patch_volume(
+          host_item, volume_map_rev, container_platform)
         self.assertEqual(result, container_item)
 
   def test_patch_volume_linux(self):

--- a/terra/utils/path.py
+++ b/terra/utils/path.py
@@ -88,8 +88,8 @@ def patch_volume(value, volume_map, container_platform='linux'):
         remainder = value_pathlib.relative_to(host_pathlib)
       except ValueError:
         continue
-      results.append( (len(str(remainder)),
-                       str(container_pathlib / remainder)) )
+      results.append((len(str(remainder)),
+                      str(container_pathlib / remainder)))
 
     # return "best" result with minimum remainder length
     if results:

--- a/terra/utils/path.py
+++ b/terra/utils/path.py
@@ -82,12 +82,18 @@ def patch_volume(value, volume_map, container_platform='linux'):
     value_pathlib = value_pathlib.expanduser().resolve()
     volume_map_pathlib = pathlib_map(volume_map, container_platform)
 
+    results = []
     for host_pathlib, container_pathlib in volume_map_pathlib:
       try:
         remainder = value_pathlib.relative_to(host_pathlib)
       except ValueError:
         continue
-      return str(container_pathlib / remainder)
+      results.append( (len(str(remainder)),
+                       str(container_pathlib / remainder)) )
+
+    # return "best" result with minimum remainder length
+    if results:
+      return min(results, key=lambda x: x[0])[-1]
 
   return value
 


### PR DESCRIPTION
Update the function `utils.path.patch_volume` which translates a path value according to a volume_map. The function previously selected the first volume_map item that matches the value to translated, which means the order of the volume_map is important for successful translation. This change selects the "best" volume_map item, where "best" is defined as the volume_map item most similar to the value to be translated with the smallest remainder.

Expand the `patch_volume` tests to add volume_map items with similar prefixes, and also test a reversed volume_map to ensure volume_map order is no longer important.
