### PR TITLE
Add ability to use an empty config file

### DIFF
--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -927,7 +927,10 @@ def json_load(filename):
   # Helper function to load from json
   try:
     with open(filename, 'r') as fid:
-      return json.load(fid)
+      json_string = fid.read()
+    if not json_string: # handle /dev/null
+      json_string='{}'
+    return json.loads(json_string)
   except JSONDecodeError as e:
     logger.critical(
         f'Error parsing the JSON config file {filename}: ' + str(e))

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -928,8 +928,8 @@ def json_load(filename):
   try:
     with open(filename, 'r') as fid:
       json_string = fid.read()
-    if not json_string: # handle /dev/null
-      json_string='{}'
+    if not json_string:  # handle /dev/null
+      json_string = '{}'
     return json.loads(json_string)
   except JSONDecodeError as e:
     logger.critical(

--- a/terra/utils/cli.py
+++ b/terra/utils/cli.py
@@ -93,7 +93,7 @@ class ArgumentParser(argparse.ArgumentParser):
                       help="Override terra settings, e.g. "
                            "'--set logging.level=INFO'", action=OverrideAction)
 
-  def add_settings_file(self, **kwargs):
+  def add_settings_file(self, default_null=False, **kwargs):
     '''
     Add positional argument for settings file
     '''
@@ -108,6 +108,9 @@ class ArgumentParser(argparse.ArgumentParser):
     TERRA_SETTINGS_FILE = os.getenv('TERRA_SETTINGS_FILE')
     if TERRA_SETTINGS_FILE:
       aa_kwargs['default'] = resolve_path(TERRA_SETTINGS_FILE)
+      aa_kwargs['nargs'] = '?'
+    elif default_null:
+      aa_kwargs['default'] = os.devnull
       aa_kwargs['nargs'] = '?'
 
     # apply overrides


### PR DESCRIPTION
Adds the feature that an empty settings file is parsed like a normal empty dictionary. There are a number of reasons why this feature is useful, e.g. I don't want to create an empty json file and just want to pass in `/dev/null`/`Nul`.

Instead of hard coding `/dev/null` and `Nul`, it just allows any empty file to be parsed as `{}`.

---

I looked into changing the default value of the settings file parser to use to dev null, however the current behavior of `add_settings_file` to the argument parser already handles this by setting the settings file to required _unless_ `TERRA_SETTINGS_FILE` is set, in which case it become optional. So I decided not to unexpectedly change this behavior for all Terra projects. If this is a desired feature, we can add a parameter to `add_settings_file` to support both scenarios.

So in cases where we want the settings file to be optional, we can set `TERRA_SETTINGS_FILE` to dev null in the project.env file, `local.env`, or other environment configuration to make it behave that way.