### PR TITLE
Initial ServiceRunFailed update

### DIFF
--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -24,9 +24,9 @@ class ServiceRunFailed(Exception):
   def __init__(self, return_code=None):
     self.return_code = return_code
     if return_code is None:
-      msg = f'The service runner failed, with unknown return code'
+      msg = 'The service runner failed, with unknown return code'
     elif return_code >= 128:
-      sig = signal._int_to_enum(return_code-128, signal.Signals)
+      sig = signal._int_to_enum(return_code - 128, signal.Signals)
       if isinstance(sig, signal.Signals):
         msg = f'The service runner failed, throwing {sig.name} ({return_code})'
         if sig.name == 'SIGKILL':

--- a/terra/compute/docker.py
+++ b/terra/compute/docker.py
@@ -87,7 +87,7 @@ class Compute(BaseCompute):
                env=service_info.env)
 
     if pid.wait() != 0:
-      raise ServiceRunFailed()
+      raise ServiceRunFailed(pid.returncode)
 
   def config_service(self, service_info):
     '''

--- a/terra/compute/singularity.py
+++ b/terra/compute/singularity.py
@@ -40,7 +40,7 @@ class Compute(BaseCompute):
                env=service_info_env)
 
     if pid.wait() != 0:
-      raise ServiceRunFailed()
+      raise ServiceRunFailed(pid.returncode)
 
   def config_service(self, service_info):
     '''

--- a/terra/compute/virtualenv.py
+++ b/terra/compute/virtualenv.py
@@ -80,7 +80,7 @@ class Compute(BaseCompute):
     pid = Popen(service_info.command, env=env, executable=executable)
 
     if pid.wait() != 0:
-      raise ServiceRunFailed()
+      raise ServiceRunFailed(pid.returncode)
 
   def add_volume(self, local, no_remote=None, flags=None, prefix=None,
                  local_must_exist=False):

--- a/terra/tests/test_compute_docker.py
+++ b/terra/tests/test_compute_docker.py
@@ -81,7 +81,14 @@ class TestDockerRun(TestComputeDockerCase):
   def mock_just(_self, *args, **kwargs):
     _self.just_args = args
     _self.just_kwargs = kwargs
-    return type('blah', (object,), {'wait': lambda self: _self.return_value})()
+
+    class MockJust:
+      def wait(self):
+        return _self.return_value
+      @property
+      def returncode(self):
+        return _self.return_value
+    return MockJust()
 
   def setUp(self):
     # Mock the just call for recording

--- a/terra/tests/test_compute_docker.py
+++ b/terra/tests/test_compute_docker.py
@@ -85,6 +85,7 @@ class TestDockerRun(TestComputeDockerCase):
     class MockJust:
       def wait(self):
         return _self.return_value
+
       @property
       def returncode(self):
         return _self.return_value

--- a/terra/tests/test_compute_singularity.py
+++ b/terra/tests/test_compute_singularity.py
@@ -33,7 +33,13 @@ class TestSingular(TestComputeSingularityCase):
   def mock_just(_self, *args, **kwargs):
     _self.just_args = args
     _self.just_kwargs = kwargs
-    return type('blah', (object,), {'wait': lambda self: _self.return_value})()
+    class MockJust:
+      def wait(self):
+        return _self.return_value
+      @property
+      def returncode(self):
+        return _self.return_value
+    return MockJust()
 
   def setUp(self):
     # Mock the just call for recording

--- a/terra/tests/test_compute_singularity.py
+++ b/terra/tests/test_compute_singularity.py
@@ -33,9 +33,11 @@ class TestSingular(TestComputeSingularityCase):
   def mock_just(_self, *args, **kwargs):
     _self.just_args = args
     _self.just_kwargs = kwargs
+
     class MockJust:
       def wait(self):
         return _self.return_value
+
       @property
       def returncode(self):
         return _self.return_value

--- a/terra/tests/test_compute_virtualenv.py
+++ b/terra/tests/test_compute_virtualenv.py
@@ -40,8 +40,13 @@ class TestVirtualEnv(TestSettingsConfigureCase):
   def mock_popen(_self, *args, **kwargs):
     _self.popen_args = args
     _self.popen_kwargs = kwargs
-    # Wait will return whatever is in self.return_valu
-    return type('blah', (object,), {'wait': lambda self: _self.return_value})()
+    class MockJust:
+      def wait(self):
+        return _self.return_value
+      @property
+      def returncode(self):
+        return _self.return_value
+    return MockJust()
 
   def test_run_failed(self):
     compute = virtualenv.Compute()

--- a/terra/tests/test_compute_virtualenv.py
+++ b/terra/tests/test_compute_virtualenv.py
@@ -40,9 +40,11 @@ class TestVirtualEnv(TestSettingsConfigureCase):
   def mock_popen(_self, *args, **kwargs):
     _self.popen_args = args
     _self.popen_kwargs = kwargs
+
     class MockJust:
       def wait(self):
         return _self.return_value
+
       @property
       def returncode(self):
         return _self.return_value


### PR DESCRIPTION
Instead of having the ServiceRunFailed message tell you nothing, it at least tells you the exit code throw by the child process, and tries to decode it if it's above 127