### PR TITLE
Change the filenames generated by settings dumps

### DIFF
--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -127,6 +127,7 @@ class BaseService:
     # docker config need to be run to get the container volumes, and that has
     # to be run on the host machine. So this is calculated here.
     settings.executor.volume_map = Executor.configuration_map(self)
+    settings.terra.current_service = self.__class__.__name__
     logger.debug4("Executor Volume map: %s", settings.executor.volume_map)
 
   def post_run(self):

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -364,11 +364,16 @@ class _SetupTerraLogger():
     self.root_logger.removeHandler(self.tmp_handler)
 
     if not settings.terra.disable_settings_dump:
+      settings_dump_file = ('settings_%Y_%m_%d_%H_%M_%S_%f_'
+                            f'{settings.terra.zone}_')
+      if settings.terra.zone == 'runner':
+        settings_dump_file += f'{settings.terra.current_service}_'
+      settings_dump_file += f'{settings.terra.uuid}.json'
+
       os.makedirs(settings.settings_dir, exist_ok=True)
       settings_dump = os.path.join(
           settings.settings_dir,
-          datetime.now(timezone.utc).strftime(
-              f'settings_{settings.terra.uuid}_%Y_%m_%d_%H_%M_%S_%f.json'))
+          datetime.now(timezone.utc).strftime(settings_dump_file))
       with open(settings_dump, 'w') as fid:
         fid.write(TerraJSONEncoder.dumps(settings, indent=2))
 


### PR DESCRIPTION
The new filenames make it clear which settings file is for the controller, and which one is for the runners. It also makes it clear which service goes with which.

`terra.current_service` was also added, to know what the current service is

```
settings_2024_01_26_21_12_49_945058_controller_87c1c508-0a77-4418-a9c9-b8086e1f142a.json
settings_2024_01_26_21_13_02_852420_runner_ServiceOne_docker_87c1c508-0a77-4418-a9c9-b8086e1f142a.json
settings_2024_01_26_21_13_14_910334_runner_ServiceTwo_docker_87c1c508-0a77-4418-a9c9-b8086e1f142a.json
settings_2024_01_26_21_13_27_225612_runner_ServiceThree_docker_87c1c508-0a77-4418-a9c9-b8086e1f142a.json
settings_2024_01_26_21_13_41_280132_runner_ServiceFour_docker_87c1c508-0a77-4418-a9c9-b8086e1f142a.json
```