### PR TITLE
yaml.safe_load

### DIFF
--- a/terra/compute/docker.py
+++ b/terra/compute/docker.py
@@ -104,7 +104,7 @@ class Compute(BaseCompute):
     pid = just(*args, stdout=PIPE,
                **optional_args,
                env=service_info.env)
-    return yaml.load(pid.communicate()[0], Loader=yaml.Loader)
+    return yaml.safe_load(pid.communicate()[0])
 
   def get_volume_map(self, config, service_info):
     # TODO: Make an OrderedDict

--- a/terra/tests/test_compute_docker.py
+++ b/terra/tests/test_compute_docker.py
@@ -396,7 +396,7 @@ volumes:
 
 
 def mock_config(*args, **kwargs):
-  return yaml.load(mock_yaml, Loader=yaml.Loader)
+  return yaml.safe_load(mock_yaml)
 
 
 class TestDockerMap(TestComputeDockerCase):


### PR DESCRIPTION
`yaml.load` -> `yaml.safe_load` 

https://security.openstack.org/guidelines/dg_avoid-dangerous-input-parsing-libraries.html