### PR TITLE
PIPENV_EXE

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -466,6 +466,7 @@ function terra_caseify()
       ask_question "Do you want to add \"${output_dir}/${platform_bin}\" to your local.env automatically?" add_to_local y
       if [ "${add_to_local}" == "1" ]; then
         echo $'\n'"PATH=\"${output_dir}/${platform_bin}:\${PATH}\"" >> "${TERRA_CWD}/local.env"
+        echo "PIPENV_EXE=\"${output_dir}/${platform_bin}/pipenv\"" >> "${TERRA_CWD}/local.env"
       fi
       ;;
 


### PR DESCRIPTION
PR #200 forces the command `pipenv` to be located at `${TERRA_CWD}/build/pipenv/bin/pipenv` by default.  Users can override this location by setting `PIPENV_EXE`, but this override is not automatically created for users that place the terra python/pipenv in a non-default location.

For example, running `just terra setup --download --dir ./foo` places `pipenv` at `${TERRA_CWD}/foo/bin/pipenv`.  Users must then manually define `PIPENV_EXE` to ensure terra can discover the command location.

This PR adds the `PIPENV_EXE` environment variable to the terra `local.env` file during `just terra setup` so users need not define the variable themselves.