### PR TITLE
Terra cleanup and troubleshoot

### DIFF
--- a/.troubleshoot.d/terra_installed
+++ b/.troubleshoot.d/terra_installed
@@ -1,0 +1,14 @@
+#!/usr/bin/env false
+
+function troubleshoot_terra_pipenv()
+{
+  cd "${TERRA_TERRA_DIR}"
+  . setup.env
+  just terra run python -c "import terra; terra.settings"
+}
+
+function error_terra_pipenv()
+{
+  echo "${RED}Terra does not appear to be working"
+  echo "Did you run: ${YELLOW}just sync${RED}? (That should run \"just terra sync\" for you)${NC}"
+}

--- a/Justfile
+++ b/Justfile
@@ -307,7 +307,7 @@ function terra_caseify()
         touch "${TERRA_CWD}/.just_synced"
       fi
 
-      if [ -s "${TERRA_SKIP_DOCKER_COMPOSE_CHECK+set}" ] && ! "${DOCKER_COMPOSE[@]}" &> /dev/null; then
+      if [ -z "${TERRA_SKIP_DOCKER_COMPOSE_CHECK+set}" ] && ! "${DOCKER_COMPOSE[@]}" &> /dev/null; then
         source "${VSI_COMMON_DIR}/linux/colors.bsh"
         echo "${RED}The docker compose plugin does not appear to be installed.${NC}"
         echo "Please have IT install the 'docker-compose-plugin' or install a local copy in your home directory:"

--- a/Justfile
+++ b/Justfile
@@ -135,7 +135,7 @@ function terra_caseify()
     run) # Run python module/cli in terra
       # 2 is the exit code of an error in arg parsing
       # 62 for any other terra error
-      local JUST_IGNORE_EXIT_CODES='2$|^62'
+      local JUST_IGNORE_EXIT_CODES=${JUST_IGNORE_EXIT_CODES-'2$|^62'}
       if [ "${JUST_RODEO-}" = "1" ]; then
         extra_args=$#
         local app_name="${1}"

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -185,11 +185,13 @@ class BaseCompute:
         elif crash.code >= 128:
           sig = signal._int_to_enum(crash.code - 128, signal.Signals)
           if isinstance(sig, signal.Signals):
-            msg = f'The service runner failed, throwing {sig.name} ({crash.code})'
+            msg = f'The service runner failed, throwing {sig.name} ' + \
+                  f'({crash.code})'
             if sig.name == 'SIGKILL':
               msg += '. This could be due to out of memory'
           else:
-            msg = f'The service runner failed, throwing return code {crash.code}'
+            msg = 'The service runner failed, ' + \
+                  f'throwing return code {crash.code}'
         else:
           msg = f'The service runner failed, throwing return code {crash.code}'
         logger.critical(msg)

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -19,26 +19,13 @@ from terra.logger import (
 logger = getLogger(__name__)
 
 
-class ServiceRunFailed(Exception):
+class ServiceRunFailed(SystemExit):
   ''' Exception thrown when a service runner returns non-zero
   '''
 
-  def __init__(self, return_code=None):
-    self.return_code = return_code
-    if return_code is None:
-      msg = 'The service runner failed, with unknown return code'
-    elif return_code >= 128:
-      sig = signal._int_to_enum(return_code - 128, signal.Signals)
-      if isinstance(sig, signal.Signals):
-        msg = f'The service runner failed, throwing {sig.name} ({return_code})'
-        if sig.name == 'SIGKILL':
-          msg += '. This could be due to out of memory'
-      else:
-        msg = f'The service runner failed, throwing return code {return_code}'
-    else:
-      msg = f'The service runner failed, throwing return code {return_code}'
-
-    super().__init__(msg)
+  def __init__(self, code=None):
+    self.code = code
+    super().__init__(code)
 
 
 class BaseService:
@@ -189,8 +176,24 @@ class BaseCompute:
         pre_call(*args, **kwargs)
 
       # Call command implementation
-      rv = self.__getattribute__(implementation)(
-          service_info, *args, **kwargs)
+      try:
+        rv = self.__getattribute__(implementation)(
+            service_info, *args, **kwargs)
+      except ServiceRunFailed as crash:
+        if crash.code is None:
+          msg = 'The service runner failed, with unknown return code'
+        elif crash.code >= 128:
+          sig = signal._int_to_enum(crash.code - 128, signal.Signals)
+          if isinstance(sig, signal.Signals):
+            msg = f'The service runner failed, throwing {sig.name} ({crash.code})'
+            if sig.name == 'SIGKILL':
+              msg += '. This could be due to out of memory'
+          else:
+            msg = f'The service runner failed, throwing return code {crash.code}'
+        else:
+          msg = f'The service runner failed, throwing return code {crash.code}'
+        logger.critical(msg)
+        raise crash
 
       # Check and call post_ call
       post_call = getattr(service_info, 'post_' + name, None)

--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -105,6 +105,8 @@ class ContainerService(BaseService):
     with open(temp_dir / 'config.json', 'w') as fid:
       json.dump(container_config, fid)
 
+    self.env['JUST_IGNORE_EXIT_CODES'] = '62'
+
   def post_run(self):
     super().post_run()
     # Delete temp_dir

--- a/terra/core/exceptions.py
+++ b/terra/core/exceptions.py
@@ -65,7 +65,8 @@ def setup_logging_exception_hook():
     try:
       # sys.executable for frozen, untested?
 
-      # May not work when frozen or various other corner cases. Interactive python/Jupyter
+      # May not work when frozen or various other corner cases. Interactive
+      # python/Jupyter
       spec = sys.modules['__main__'].__spec__
       if spec is None:
         # Interactive, just use cwd and hope for best
@@ -82,12 +83,16 @@ def setup_logging_exception_hook():
 
       extracted_summary = traceback.extract_tb(exc_traceback)
 
-      our_scripts = [any(x.filename.startswith(main_dir) for main_dir in main_dirs) for x in extracted_summary]
+      our_scripts = [any(x.filename.startswith(main_dir)
+                     for main_dir in main_dirs) for x in extracted_summary]
 
       msg = extracted_summary.format()
-      msg = ['\x1b[31m' + msg + '\x1b[0m' if color else msg for msg, color in zip(extracted_summary.format(), our_scripts)]
+      msg = ['\x1b[31m' + msg + '\x1b[0m'
+             if color else msg
+             for msg, color in zip(extracted_summary.format(), our_scripts)]
       msg = ''.join(msg)
-      msg += '\x1b[33m' + ''.join(traceback.format_exception_only(exc_value)) + '\x1b[0m'
+      msg += '\x1b[33m' + \
+             ''.join(traceback.format_exception_only(exc_value)) + '\x1b[0m'
       print(msg, file=sys.stderr, end='')
       sys.exit(ranButFailedExitCode)
     except Exception:

--- a/terra/core/exceptions.py
+++ b/terra/core/exceptions.py
@@ -1,8 +1,9 @@
+import os
 import sys
 import platform
 import traceback
 
-handledExitCode = 62  # 20 + 5 + 18 + 18 + 1
+ranButFailedExitCode = 62  # 20 + 5 + 18 + 18 + 1
 
 
 class NoStackException(Exception):
@@ -46,7 +47,7 @@ def setup_logging_exception_hook():
       # Skip calling the original_hook when I don't want to print the stack
       if issubclass(exc_type, NO_STACK_EXCEPTIONS):
         print(f'ERROR: ({exc_type.__name__}) {exc_value}', file=sys.stderr)
-        sys.exit(handledExitCode)
+        sys.exit(ranButFailedExitCode)
 
     except Exception:  # pragma: no cover
       print('There was an exception logging in the exception handler!',
@@ -61,7 +62,36 @@ def setup_logging_exception_hook():
     print(f'Exception in {zone} on {platform.node()}',
           file=sys.stderr)
 
-    return original_hook(exc_type, exc_value, exc_traceback)
+    try:
+      # sys.executable for frozen, untested?
+
+      # May not work when frozen or various other corner cases. Interactive python/Jupyter
+      spec = sys.modules['__main__'].__spec__
+      if spec is None:
+        # Interactive, just use cwd and hope for best
+        main_dirs = [os.getcwd()]
+      else:
+        top_module = sys.modules.get(spec.name.split('.')[0])
+        if top_module:
+          spec = top_module.__spec__
+
+        try:
+          main_dirs = [os.path.dirname(spec.origin)]
+        except AttributeError:
+          main_dirs = spec.submodule_search_locations
+
+      extracted_summary = traceback.extract_tb(exc_traceback)
+
+      our_scripts = [any(x.filename.startswith(main_dir) for main_dir in main_dirs) for x in extracted_summary]
+
+      msg = extracted_summary.format()
+      msg = ['\x1b[31m' + msg + '\x1b[0m' if color else msg for msg, color in zip(extracted_summary.format(), our_scripts)]
+      msg = ''.join(msg)
+      msg += '\x1b[33m' + ''.join(traceback.format_exception_only(exc_value)) + '\x1b[0m'
+      print(msg, file=sys.stderr, end='')
+      sys.exit(ranButFailedExitCode)
+    except Exception:
+      return original_hook(exc_type, exc_value, exc_traceback)
 
   # Replace the hook
   sys.excepthook = handle_exception

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -347,7 +347,8 @@ def logging_hostname(self):
 
   node_name = platform.node()
 
-  if os.environ.get('TERRA_RESOLVE_HOSTNAME', None) == "1" or check_is_loopback(node_name):
+  if os.environ.get('TERRA_RESOLVE_HOSTNAME', None) == "1" or \
+     check_is_loopback(node_name):
     s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
     try:
       # doesn't even have to be reachable

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -393,6 +393,8 @@ global_templates = [
     {
       "logging": {
         "level": "ERROR",
+        "severe_level": "ERROR",
+        "severe_buffer_length": 20,
         "format": "%(asctime)s (%(hostname)s:%(zone)s): "
                   "%(levelname)s/%(processName)s - %(filename)s - %(message)s",
         "date_format": None,

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -164,7 +164,7 @@ import copy
 from json.decoder import JSONDecodeError
 
 from terra.core.exceptions import (
-  ImproperlyConfigured, ConfigurationWarning, handledExitCode
+  ImproperlyConfigured, ConfigurationWarning, ranButFailedExitCode
 )
 # Do not import terra.logger or terra.signals here, or any module that
 # imports them
@@ -936,10 +936,10 @@ def json_load(filename):
   except JSONDecodeError as e:
     logger.critical(
         f'Error parsing the JSON config file {filename}: ' + str(e))
-    raise SystemExit(handledExitCode)
+    raise SystemExit(ranButFailedExitCode)
   except FileNotFoundError as e:
     logger.critical('Cannot find JSON config file: ' + str(e))
-    raise SystemExit(handledExitCode)
+    raise SystemExit(ranButFailedExitCode)
 
 
 import terra.logger  # noqa

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -111,8 +111,10 @@ class RingMemoryHandler(logging.handlers.MemoryHandler):
   def activate_ring(self):
     '''
     Once ``self.capacity`` and ``setLevel`` are set, call ``activate_ring`` to
-    turn on the ring buffer. This is delayed from ``__init__`` so that you can
-    have a change to log everything before you know the max severity and count.
+    enable the ring buffer. This is delayed from ``__init__`` so that you can
+    capture all the logs before you know the max severity and count; then
+    keep only the last ``self.capacity`` messages of severity ``self.level`` or
+    higher.
     '''
     with self.lock:
       self.buffer = deque((b for b in self.buffer if b.levelno >= self.level),

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -96,10 +96,12 @@ __all__ = ['getLogger', 'CRITICAL', 'ERROR', 'INFO', 'FATAL', 'WARN',
 class RingMemoryHandler(logging.handlers.MemoryHandler):
   def flush(self):
     if len(self.buffer) >= self.capacity:
-      self.buffer=self.buffer[-self.capacity:]
+      self.buffer = self.buffer[-self.capacity:]
     super().flush()
+
   def filter_level(self, level):
-     self.buffer = [b for b in self.buffer if b.levelno >= self.level]
+    self.buffer = [b for b in self.buffer if b.levelno >= self.level]
+
 
 class HandlerLoggingContext(object):
   '''

--- a/terra/tests/test_compute_docker.py
+++ b/terra/tests/test_compute_docker.py
@@ -121,8 +121,8 @@ class TestDockerRun(TestComputeDockerCase):
       with self.assertRaises(base.ServiceRunFailed):
         compute.run(MockJustService())
 
-    self.assertIn(f'The service runner failed, throwing return code {self.return_value}',
-                  str(cm.output))
+    self.assertIn('The service runner failed, throwing return code '
+                  f'{self.return_value}', str(cm.output))
 
 
 ###############################################################################

--- a/terra/tests/test_compute_docker.py
+++ b/terra/tests/test_compute_docker.py
@@ -116,8 +116,13 @@ class TestDockerRun(TestComputeDockerCase):
 
     # Test a non-zero return value
     self.return_value = 1
-    with self.assertRaises(base.ServiceRunFailed):
-      compute.run(MockJustService())
+
+    with self.assertLogs() as cm:
+      with self.assertRaises(base.ServiceRunFailed):
+        compute.run(MockJustService())
+
+    self.assertIn(f'The service runner failed, throwing return code {self.return_value}',
+                  str(cm.output))
 
 
 ###############################################################################

--- a/terra/tests/test_compute_singularity.py
+++ b/terra/tests/test_compute_singularity.py
@@ -71,8 +71,8 @@ class TestSingular(TestComputeSingularityCase):
       with self.assertRaises(base.ServiceRunFailed):
         compute.run(MockJustService())
 
-    self.assertIn(f'The service runner failed, throwing return code {self.return_value}',
-                  str(cm.output))
+    self.assertIn('The service runner failed, throwing return code '
+                  f'{self.return_value}', str(cm.output))
 
   def test_run_multiple_compose_files(self):
     compute = singularity.Compute()
@@ -99,8 +99,8 @@ class TestSingular(TestComputeSingularityCase):
       with self.assertRaises(base.ServiceRunFailed):
         compute.run(MockJustService())
 
-    self.assertIn(f'The service runner failed, throwing return code {self.return_value}',
-                  str(cm.output))
+    self.assertIn('The service runner failed, throwing return code '
+                  f'{self.return_value}', str(cm.output))
 
 
 class TestSingularityConfig(TestComputeSingularityCase):

--- a/terra/tests/test_compute_singularity.py
+++ b/terra/tests/test_compute_singularity.py
@@ -66,8 +66,13 @@ class TestSingular(TestComputeSingularityCase):
 
     # Test a non-zero return value
     self.return_value = 1
-    with self.assertRaises(base.ServiceRunFailed):
-      compute.run(MockJustService())
+
+    with self.assertLogs() as cm:
+      with self.assertRaises(base.ServiceRunFailed):
+        compute.run(MockJustService())
+
+    self.assertIn(f'The service runner failed, throwing return code {self.return_value}',
+                  str(cm.output))
 
   def test_run_multiple_compose_files(self):
     compute = singularity.Compute()
@@ -89,8 +94,13 @@ class TestSingular(TestComputeSingularityCase):
 
     # Test a non-zero return value
     self.return_value = 1
-    with self.assertRaises(base.ServiceRunFailed):
-      compute.run(MockJustService())
+
+    with self.assertLogs() as cm:
+      with self.assertRaises(base.ServiceRunFailed):
+        compute.run(MockJustService())
+
+    self.assertIn(f'The service runner failed, throwing return code {self.return_value}',
+                  str(cm.output))
 
 
 class TestSingularityConfig(TestComputeSingularityCase):

--- a/terra/tests/test_compute_virtualenv.py
+++ b/terra/tests/test_compute_virtualenv.py
@@ -58,12 +58,16 @@ class TestVirtualEnv(TestSettingsConfigureCase):
 
     import warnings
     with warnings.catch_warnings():
-      with self.assertRaises(base.ServiceRunFailed):
-        warnings.simplefilter('ignore')
-        compute.run(service)
-      # Delete the service now, so that the temp directory is cleaned up, so
-      # the warning is captured now, in the context
-      del service
+      with self.assertLogs() as cm:
+        with self.assertRaises(base.ServiceRunFailed):
+          warnings.simplefilter('ignore')
+          compute.run(service)
+        # Delete the service now, so that the temp directory is cleaned up, so
+        # the warning is captured now, in the context
+        del service
+
+    self.assertIn(f'The service runner failed, throwing return code {self.return_value}',
+                  str(cm.output))
 
   def test_run_simple(self):
     compute = virtualenv.Compute()

--- a/terra/tests/test_compute_virtualenv.py
+++ b/terra/tests/test_compute_virtualenv.py
@@ -66,8 +66,8 @@ class TestVirtualEnv(TestSettingsConfigureCase):
         # the warning is captured now, in the context
         del service
 
-    self.assertIn(f'The service runner failed, throwing return code {self.return_value}',
-                  str(cm.output))
+    self.assertIn('The service runner failed, throwing return code '
+                  f'{self.return_value}', str(cm.output))
 
   def test_run_simple(self):
     compute = virtualenv.Compute()

--- a/terra/tests/test_logger.py
+++ b/terra/tests/test_logger.py
@@ -84,7 +84,6 @@ class TestLogger(TestLoggerConfigureCase):
       # handling" path. This will cause save_exec_info to be called
       raise
 
-
     with mock.patch('sys.stderr', new_callable=io.StringIO):
       with mock.patch('sys.exit', new=mock_exit):
         with self.assertLogs() as cm:
@@ -288,5 +287,6 @@ class TestUnitTests(TestCase):
         "restore it.")
 
   def last_test_excepthook(self):
-    # Make sure no test messed with the exception hook without using the correct TestLoggerCase
+    # Make sure no test messed with the exception hook without using the
+    # correct TestLoggerCase
     self.assertEqual(sys.excepthook.__qualname__, 'excepthook')


### PR DESCRIPTION
- Updating VSI Common to include new troubleshoot
- Service runners errors now have a more succinct stack trace
  - No extra terra stack trace. This adds no additional information
  - No additional just stack trace. This adds no additional information
  - Service Runner uncaught exception result in an exit 62 instead exit 1..
- A "Report" is printed out at the end of a terra run.
  - Currently this means the last N (`settings.logging.severe_buffer_length`, default: 20) messages of severity (`settings.logging.severe_level` default: Error) are printed out again when a terra run concludes.