### PR TITLE
Fix stack frames being cleared when using a debugger

### DIFF
--- a/terra/executor/sync.py
+++ b/terra/executor/sync.py
@@ -1,3 +1,4 @@
+import sys
 from threading import Lock
 from traceback import clear_frames
 
@@ -31,7 +32,8 @@ class SyncExecutor(BaseExecutor):
       try:
         result = fn(*args, **kwargs)
       except BaseException as e:
-        clear_frames(e.__traceback__)
+        if getattr(sys.excepthook, 'debugger', None) is None:
+          clear_frames(e.__traceback__)
         f.set_exception(e)
       else:
         f.set_result(result)

--- a/terra/executor/thread.py
+++ b/terra/executor/thread.py
@@ -1,3 +1,4 @@
+import sys
 import concurrent.futures
 import traceback
 
@@ -9,7 +10,8 @@ __all__ = ['ThreadPoolExecutor']
 
 def auto_clear_exception_frames(future):
   exc = future.exception()
-  if exc is not None:
+  if getattr(sys.excepthook, 'debugger', None) is None and \
+     exc is not None:
     traceback.clear_frames(exc.__traceback__)
 
 

--- a/terra/utils/cli.py
+++ b/terra/utils/cli.py
@@ -50,6 +50,7 @@ class DbStopAction(argparse.Action):
         pdb.pm()
         original_hook(type, value, tb)
       sys.excepthook = hook
+    # Set a flag used by the executors, so the stack frames don't get cleared during debugging
     sys.excepthook.debugger = debugger
 
 

--- a/terra/utils/cli.py
+++ b/terra/utils/cli.py
@@ -29,9 +29,7 @@ class DbStopAction(argparse.Action):
 
     try:
       if debugger == "pdb":
-        # This doesn't exist, and will cause an ImportError
-        import vsi.tools.vdb_pdb
-        vsi.tools.vdb_pdb.dbstop_if_error()
+        raise ImportError("pdb")
       elif debugger == "ipdb":
         import vsi.tools.vdb_ipdb
         vsi.tools.vdb_ipdb.dbstop_if_error()
@@ -52,6 +50,7 @@ class DbStopAction(argparse.Action):
         pdb.pm()
         original_hook(type, value, tb)
       sys.excepthook = hook
+    sys.excepthook.debugger = debugger
 
 
 class OverrideAction(argparse.Action):

--- a/terra/utils/cli.py
+++ b/terra/utils/cli.py
@@ -50,7 +50,8 @@ class DbStopAction(argparse.Action):
         pdb.pm()
         original_hook(type, value, tb)
       sys.excepthook = hook
-    # Set a flag used by the executors, so the stack frames don't get cleared during debugging
+    # Set a flag used by the executors, so the stack frames don't get cleared
+    # during debugging
     sys.excepthook.debugger = debugger
 
 


### PR DESCRIPTION
The fix in #151 introduced a new behavior, where debugging tasks using dbstop no longer included any stack frames, meaning none of the variables could be checked.

This was done to stop many exceptions from consuming large amounts of memory, especially when some tasks throwing exceptions were ok.

So now, when the dbstop flags, this memory leak prevention code is disabled.