### PR TITLE
remove filelock constraint

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,6 +14,6 @@ setup(name="terra",
         "jstyleson",
         # I use signal and task from celery, no matter what
         "celery",
-        "filelock<3.12"
+        "filelock"
       ]
 )

--- a/terra/executor/resources.py
+++ b/terra/executor/resources.py
@@ -204,7 +204,7 @@ class Resource:
       return lock._lock_counter
     else:
       raise AttributeError(f"{type(lock)} object has no attribute "
-                            "'lock_counter' or '_lock_counter'")
+                           "'lock_counter' or '_lock_counter'")
 
   def _acquire(self, lock_file, resource_index, repeat):
     lock = self.FileLock(lock_file, 0)

--- a/terra/executor/resources.py
+++ b/terra/executor/resources.py
@@ -191,6 +191,21 @@ class Resource:
       return False
     return self._local.lock.is_locked
 
+  @property
+  def lock_counter(self):
+
+    # filelock>=3.12 uses ``lock_counter``
+    # filelock<3.12 uses ``_lock_counter``
+    # https://github.com/tox-dev/filelock/pull/232
+    lock = self._local.lock
+    if hasattr(lock, 'lock_counter'):
+      return lock.lock_counter
+    elif hasattr(lock, '_lock_counter'):
+      return lock._lock_counter
+    else:
+      raise AttributeError(f"{type(lock)} object has no attribute "
+                            "'lock_counter' or '_lock_counter'")
+
   def _acquire(self, lock_file, resource_index, repeat):
     lock = self.FileLock(lock_file, 0)
     lock.acquire()
@@ -282,7 +297,7 @@ class Resource:
     if not self.is_locked:
       raise ValueError('Release called with no lock acquired')
 
-    if not force and self._local.lock._lock_counter > 1:
+    if not force and self.lock_counter > 1:
       self._local.lock.release()
       return
 

--- a/terra/tests/test_executor_resources.py
+++ b/terra/tests/test_executor_resources.py
@@ -151,14 +151,14 @@ class TestResourceLock(TestResourceCase):
     self.assertFalse(test.is_locked)
     test.acquire()
     self.assertTrue(test.is_locked)
-    self.assertEqual(test._local.lock._lock_counter, 1)
+    self.assertEqual(test.lock_counter, 1)
     test.acquire()
     self.assertTrue(test.is_locked)
-    self.assertEqual(test._local.lock._lock_counter, 2)
+    self.assertEqual(test.lock_counter, 2)
 
     test.release()
     self.assertTrue(test.is_locked)
-    self.assertEqual(test._local.lock._lock_counter, 1)
+    self.assertEqual(test.lock_counter, 1)
 
     test.release()
     self.assertFalse(test.is_locked)
@@ -196,7 +196,7 @@ class TestResourceLock(TestResourceCase):
     with resource as r2:
       with resource as r3:
         self.assertTrue(resource.is_locked)
-        self.assertEqual(resource._local.lock._lock_counter, 2)
+        self.assertEqual(resource.lock_counter, 2)
       self.assertTrue(resource.is_locked)
     self.assertFalse(resource.is_locked)
 


### PR DESCRIPTION
Remove `filelock` package version constraint.  `filelock<3.12` uses a `_lock_counter` property, while later packages use a `lock_counter` property (without the leading underscore).  Here, we check for the existence of both properties. Related to the previously closed PR #152.
