### PR TITLE
Fix issues when terra apps use TERRA_CWD

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -23,7 +23,7 @@ source "${VSI_COMMON_DIR}/linux/web_tools.bsh"
 if [ "${JUSTFILE}" != "${BASH_SOURCE[0]}" ]; then
   JUST_HELP_FILES+=("${BASH_SOURCE[0]}")
 else
-  cd "${TERRA_CWD}"
+  cd "${TERRA_TERRA_DIR}"
   # Allow terra to be run as a non-plugin too
   function caseify()
   {
@@ -50,9 +50,9 @@ function Terra_Pipenv()
         return 1
       fi
     fi
-    ${DRYRUN} env PIPENV_PIPFILE="${TERRA_PIPENV_PIPFILE-${TERRA_CWD}/Pipfile}" "${PIPENV_EXE-${TERRA_CWD}/build/pipenv/bin/pipenv}" ${@+"${@}"} || return $?
+    ${DRYRUN} env PIPENV_PIPFILE="${TERRA_PIPENV_PIPFILE-${TERRA_TERRA_DIR}/Pipfile}" "${PIPENV_EXE-${TERRA_TERRA_DIR}/build/pipenv/bin/pipenv}" ${@+"${@}"} || return $?
   else
-    Just-docker-compose -f "${TERRA_CWD}/docker-compose-main.yml" run ${TERRA_PIPENV_IMAGE-terra} pipenv ${@+"${@}"} || return $?
+    Just-docker-compose -f "${TERRA_TERRA_DIR}/docker-compose-main.yml" run ${TERRA_PIPENV_IMAGE-terra} pipenv ${@+"${@}"} || return $?
   fi
 }
 
@@ -77,25 +77,25 @@ function terra_caseify()
         Docker compose build ${@+"${@}"}
         extra_args=$#
       else
-        justify build recipes-auto "${TERRA_CWD}/docker/"*.Dockerfile
-        Docker compose -f "${TERRA_CWD}/docker-compose-main.yml" build
+        justify build recipes-auto "${TERRA_TERRA_DIR}/docker/"*.Dockerfile
+        Docker compose -f "${TERRA_TERRA_DIR}/docker-compose-main.yml" build
         if [ "${TERRA_LOCAL-}" = "0" ]; then
-          COMPOSE_FILE="${TERRA_CWD}/docker-compose-main.yml" justify docker compose clean terra-venv
+          COMPOSE_FILE="${TERRA_TERRA_DIR}/docker-compose-main.yml" justify docker compose clean terra-venv
         fi
         justify terra build-services
       fi
       ;;
 
     ci_load) # Load images and rebuild from dockerhub cache
-      justify ci load-recipes-auto "${TERRA_CWD}/docker/terra.Dockerfile"
-      justify ci load-services "${TERRA_CWD}/docker-compose-main.yml" terra terra_pipenv ${@+"${@}"}
+      justify ci load-recipes-auto "${TERRA_TERRA_DIR}/docker/terra.Dockerfile"
+      justify ci load-services "${TERRA_TERRA_DIR}/docker-compose-main.yml" terra terra_pipenv ${@+"${@}"}
       # terra_pipenv is needed for `justify terra pipenv sync --dev` in terra_pep8
       extra_args=$#
       ;;
 
     terra_build-services) # Build services. Takes arguments that are passed to the \
                     # docker buildx bake command, such as "redis"
-      Docker buildx bake -f "${TERRA_CWD}/docker-compose.yml" ${@+"${@}"}
+      Docker buildx bake -f "${TERRA_TERRA_DIR}/docker-compose.yml" ${@+"${@}"}
       extra_args=$#
       ;;
 

--- a/terra.env
+++ b/terra.env
@@ -28,7 +28,7 @@ fi
 
 # This directory is added to the container using the docker compose file. This mechanism
 # should only be used when the directory is guaranteed to exist
-: ${TERRA_TERRA_DIR=${TERRA_CWD}}
+: ${TERRA_TERRA_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")"; pwd)"} # Do not copy TERRA_CWD here, so an app can define TERRA_CWD separately
 : ${TERRA_TERRA_DIR_DOCKER=/terra}
 : ${TERRA_TERRA_DIR_TYPE=bind}
 
@@ -76,7 +76,7 @@ fi
 # The hostname singularity containers will use to connect to redis. Leave blank to auto determine using the ``HOSTNAME`` envvar or ``hostname`` command
 : ${TERRA_REDIS_HOSTNAME_SINGULAR=}
 
-: ${TERRA_SINGULAR_COMPOSE_FILES=${TERRA_CWD}/singular-compose.env}
+: ${TERRA_SINGULAR_COMPOSE_FILES=${TERRA_TERRA_DIR}/singular-compose.env}
 
 #**
 # .. envvar:: TERRA_REDIS_SECRET
@@ -203,9 +203,9 @@ set_array_default TERRA_SPHINX_AUTODOC_EXCLUDE_DIRS terra/tests
 # single host. This way all of the docker resources are prefixed with a unique
 # name and do not collide
 source "${VSI_COMMON_DIR}/linux/just_files/docker_functions.bsh"
-: ${COMPOSE_PROJECT_NAME=$(docker_compose_sanitize_project_name "${TERRA_CWD}" "${TERRA_USERNAME}")}
+: ${COMPOSE_PROJECT_NAME=$(docker_compose_sanitize_project_name "${TERRA_TERRA_DIR}" "${TERRA_USERNAME}")}
 
-: ${COMPOSE_FILE=${TERRA_CWD}/docker-compose-main.yml}
+: ${COMPOSE_FILE=${TERRA_TERRA_DIR}/docker-compose-main.yml}
 
 # `pipenv sync` fails when seeded with pip versions 20.3.0 and newer
 # The reported error involves mismatched metadata


### PR DESCRIPTION
Terra apps will no longer use an artificial prefix (e.g. TERRA_XYZ_...), but TERRA_... prefix directly (e.g. TERRA_CWD). So now for pure terra variables, they will be TERRA_TERRA_.... This pattern will allow for terra justfile-plugin to more easily work with any terra app, especially with the multi app work coming up.