### PR TITLE
Remove distutils for shutil

### DIFF
--- a/terra/compute/utils.py
+++ b/terra/compute/utils.py
@@ -32,7 +32,7 @@ import os
 from os import environ as env
 from shlex import quote
 from subprocess import Popen
-import distutils.spawn
+import shutil
 
 from vsi.tools.diff import dict_diff
 
@@ -201,7 +201,7 @@ def just(*args, **kwargs):
   # 0, 0, os.environ, None, None) even fails.
   # Microsoft probably has a special exception for the word "bash" that
   # calls WSL bash on execute :(
-  kwargs['executable'] = distutils.spawn.find_executable('bash')
+  kwargs['executable'] = shutil.which('bash')
   # Have to call bash for windows compatibility, no shebang support
   pid = Popen(('bash', 'just') + args, env=just_env, **kwargs)
   return pid

--- a/terra/compute/virtualenv.py
+++ b/terra/compute/virtualenv.py
@@ -1,4 +1,4 @@
-import distutils.spawn
+import shutil
 import json
 import os
 from subprocess import Popen
@@ -58,8 +58,8 @@ class Compute(BaseCompute):
     # executable is not found on the path, possibly because Popen doesn't
     # search the env's path, but this will manually search and find the right
     # command
-    executable = distutils.spawn.find_executable(service_info.command[0],
-                                                 path=env['PATH'])
+    executable = shutil.which(service_info.command[0],
+                              path=env['PATH'])
 
     # Check if the executable was found in the virtualenv_dir.
     # If it wasn't, warn the user in case they made a mistake


### PR DESCRIPTION
Distutils is deprecated as of python 3.12 (although it's part of `setuptools`)

Replacing `distutils.spawn.find_executable` with identical version `shutil.which`, which is available as of python 3.3