### PR TITLE
Add create_service_dir to compute base.py

### DIFF
--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -16,6 +16,7 @@ from terra.executor import Executor
 from terra.logger import (
   getLogger, LogRecordSocketReceiver, SkipStdErrAddFilter
 )
+from vsi.utils import file_utils
 logger = getLogger(__name__)
 
 
@@ -100,6 +101,38 @@ class BaseService:
 
     self._validate_volume(local, remote, local_must_exist=local_must_exist)
     self.volumes.append((local, remote))
+
+
+  def create_service_dir(self, service_dir, overwrite):
+    '''
+    Creates a directory for a service. If this directory already
+    exists, either it will be overwritten or a RuntimeError
+    is thrown.
+
+    Parameters
+    ----------
+    service_dir : str
+      The directory to create.
+    overwrite : bool
+      Whether the directory should be overwritten.
+
+    Raises
+    ------
+    RuntimeError
+        If the directory already exists, but overwrite is False.
+    '''
+
+    if os.path.isdir(service_dir):
+      if overwrite:
+        # TODO: Make this a question, and get user response
+        logger.warning(f"Service directory {service_dir} already exists, and overwrite "
+                      "is True. Overwriting this directory!")
+        file_utils.rmtree(service_dir, rmdir=False)
+      else:
+        raise RuntimeError(f"Service directory {service_dir} already exists, "
+                          "yet overwrite is False.")
+
+    os.makedirs(service_dir, exist_ok=True)
 
   def pre_run(self):
     '''

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -130,7 +130,7 @@ class BaseService:
         file_utils.rmtree(service_dir, keep_base_dir=True)
       else:
         raise RuntimeError(f"Service directory {service_dir} already exists, "
-                          "yet overwrite is False.")
+                           "yet overwrite is False.")
 
     os.makedirs(service_dir, exist_ok=True)
 

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -102,7 +102,6 @@ class BaseService:
     self._validate_volume(local, remote, local_must_exist=local_must_exist)
     self.volumes.append((local, remote))
 
-
   def create_service_dir(self, service_dir, overwrite):
     '''
     Creates a directory for a service. If this directory already

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -127,7 +127,7 @@ class BaseService:
         # TODO: Make this a question, and get user response
         logger.warning(f"Service directory {service_dir} already exists, and overwrite "
                       "is True. Overwriting this directory!")
-        file_utils.rmtree(service_dir, rmdir=False)
+        file_utils.rmtree(service_dir, keep_base_dir=True)
       else:
         raise RuntimeError(f"Service directory {service_dir} already exists, "
                           "yet overwrite is False.")

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -124,8 +124,8 @@ class BaseService:
     if os.path.isdir(service_dir):
       if overwrite:
         # TODO: Make this a question, and get user response
-        logger.warning(f"Service directory {service_dir} already exists, and overwrite "
-                       "is True. Overwriting this directory!")
+        logger.warning(f"Service directory {service_dir} already exists, and "
+                       "overwrite is True. Overwriting this directory!")
         file_utils.rmtree(service_dir, keep_base_dir=True)
       else:
         raise RuntimeError(f"Service directory {service_dir} already exists, "

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -126,7 +126,7 @@ class BaseService:
       if overwrite:
         # TODO: Make this a question, and get user response
         logger.warning(f"Service directory {service_dir} already exists, and overwrite "
-                      "is True. Overwriting this directory!")
+                       "is True. Overwriting this directory!")
         file_utils.rmtree(service_dir, keep_base_dir=True)
       else:
         raise RuntimeError(f"Service directory {service_dir} already exists, "

--- a/terra/tests/test_compute_base.py
+++ b/terra/tests/test_compute_base.py
@@ -36,7 +36,8 @@ class TestServiceBase(TestSettingsConfigureCase):
 
       service = terra.compute.base.BaseService()
       overwrite = False
-      # a Runtime error should occur because the directory exists and overwrite is false
+      # a Runtime error should occur because the directory exists
+      # and overwrite is false
       with self.assertRaises(RuntimeError):
         service.create_service_dir(foo_dir, overwrite)
 
@@ -51,7 +52,8 @@ class TestServiceBase(TestSettingsConfigureCase):
       dirs = os.listdir(foo_dir)
       self.assertEqual(len(dirs), 0)
 
-      # since the sub service dir was removed, test creating it wit create_service_dir
+      # since the sub service dir was removed, test creating it
+      # with create_service_dir
       service.create_service_dir(foo_sub_dir, overwrite)
       # foo dir should now have a sub directory
       dirs = os.listdir(foo_dir)

--- a/terra/tests/test_compute_base.py
+++ b/terra/tests/test_compute_base.py
@@ -1,4 +1,5 @@
 import os
+import tempfile
 from unittest import mock
 
 from terra import settings
@@ -28,6 +29,33 @@ class TestServiceBase(TestSettingsConfigureCase):
     service.add_volume("/local", "/remote")
     # Make sure it's in the list
     self.assertIn(("/local", "/remote"), service.volumes)
+
+  def test_create_service_dir(self):
+    # first create a temp dir
+    with tempfile.TemporaryDirectory() as foo_dir:
+
+      service = terra.compute.base.BaseService()
+      overwrite = False
+      # a Runtime error should occur because the directory exists and overwrite is false
+      with self.assertRaises(RuntimeError):
+        service.create_service_dir(foo_dir, overwrite)
+
+      # set overwrite to true
+      overwrite = True
+      # create a subdir to test overwriting the directory
+      # only the contents of the service dir are overwritten
+      foo_sub_dir = os.path.join(foo_dir, 'service_dir')
+      os.makedirs(foo_sub_dir, exist_ok=True)
+      service.create_service_dir(foo_dir, overwrite)
+      # foo dir should now be empty
+      dirs = os.listdir(foo_dir)
+      self.assertEqual(len(dirs), 0)
+
+      # since the sub service dir was removed, test creating it wit create_service_dir
+      service.create_service_dir(foo_sub_dir, overwrite)
+      # foo dir should now have a sub directory
+      dirs = os.listdir(foo_dir)
+      self.assertEqual(len(dirs), 1)
 
   def test_registry(self):
     with mock.patch.dict(terra.compute.base.services, clear=True):


### PR DESCRIPTION
This PR adds `create_service_dir`, which was originally in `file_utils.py`, to `compute.base.py`, since it is Terra-related.