### PR TITLE
Make a combined address for terra logging

### DIFF
--- a/docs/terra/settings.rst
+++ b/docs/terra/settings.rst
@@ -134,6 +134,18 @@ Logging Settings
 
   The format style, ``%``, ``{``, or ``$`` notation. Default: ``%``
 
+.. option:: logging.server.hostname
+
+  The hostname for the logging server. The default is to use ``platform.node()`` to get the default hostname. If the environment variable ``TERRA_RESOLVE_HOSTNAME`` is set to ``1``, then a test socket is used to determine the active IP address used for internet access, and that IP is used for the hostname.
+
+.. option:: logging.server.listen_host
+
+  The hostname or IP address the logging server will listen on. The default is :option:`logging.server.hostname`. In the case of multiple ethernet devices, this can be used to force ``localhost`` (which does not work in containers), choose a specific IP, or set to ``0.0.0.0`` for all devices.
+
+.. option:: logging.server.listen_address
+
+  The combined address the controller will use for listening. The default is ``(`` :option:`logging.server.listen_host` ``,`` :option:`logging.server.port` ``)``. Can also be used to listen via a file socket on Linux.
+
 .. option:: logging.server.port
 
   The port that the logging server will listen on. The default is to use the default logging port 9020. However when launching multiple terra runs in parallel, it may become necessary to prevent port collisions. Setting the port to ``0`` will avoid this issue and allow the OS to select a random port whose value will be accessible via ``terra.settings.loggin.server.port``.

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -306,8 +306,7 @@ class BaseCompute:
 
       # setup the TCP socket listener
       sender.tcp_logging_server = LogRecordSocketReceiver(
-          settings.logging.server.listen_address,
-          settings.logging.server.port)
+          settings.logging.server.listen_address)
       # Get and store the value of the port used, so the runners/tasks will be
       # able to connect
       if settings.logging.server.port == 0:

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -365,15 +365,25 @@ def logging_hostname(self):
 
 
 @settings_property
-def logging_listen_address(self):
+def logging_listen_host(self):
   '''
-  A :func:`settings_property` defining the address on which the main
+  A :func:`settings_property` defining the host on which the main
   logger will listen. In some environments this may need to be overridden
   (e.g., ``0.0.0.0``) to ensure appropriate capture of service & task logs.
   '''
 
   # is 0.0.0.0 as default better?
   return self.logging.server.hostname
+
+
+@settings_property
+def logging_listen_address(self):
+  '''
+  A :func:`settings_property` defining the address on which the main
+  logger will listen. In some environments this may need to be overridden
+  (e.g., ``0.0.0.0``) to ensure appropriate capture of service & task logs.
+  '''
+  return (self.logging.server.listen_host, self.logging.server.port)
 
 
 @settings_property
@@ -423,7 +433,8 @@ global_templates = [
           # different (such as celery and spark)
           "hostname": logging_hostname,
           "port": DEFAULT_TCP_LOGGING_PORT,
-          "listen_address": logging_listen_address,
+          "listen_host": logging_listen_host,
+          "listen_address": logging_listen_address
         },
         "log_file": log_file,
       },

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -209,10 +209,10 @@ class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
 
   allow_reuse_address = True
 
-  def __init__(self, host='localhost',
-               port=logging.handlers.DEFAULT_TCP_LOGGING_PORT,
+  def __init__(self, address=('localhost',
+                              logging.handlers.DEFAULT_TCP_LOGGING_PORT),
                handler=LogRecordStreamHandler):
-    socketserver.ThreadingTCPServer.__init__(self, (host, port), handler)
+    socketserver.ThreadingTCPServer.__init__(self, address, handler)
     self.abort = False
     self.ready = False
     self.timeout = 0.1


### PR DESCRIPTION
The first step to setting up file sockets, so that logging will work in WSL and we don't have to use an actual IP/port for basic logging. (For distributed computers (i.e. celery) we will always need to use IP and port).