### PR TITLE
File socket for terra logging

### DIFF
--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -304,7 +304,6 @@ class BaseCompute:
         os.makedirs(settings.processing_dir, exist_ok=True)
 
       if settings.logging.server.family == "AF_UNIX":
-        # import pdb; pdb.set_trace()
         socket_dir = Path(settings.logging.server.listen_address).parent
         os.makedirs(socket_dir, exist_ok=True)
         temp_filename = socket_dir / (

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -306,7 +306,8 @@ class BaseCompute:
 
       # setup the TCP socket listener
       sender.tcp_logging_server = LogRecordSocketReceiver(
-          settings.logging.server.listen_address)
+          settings.logging.server.listen_address,
+          settings.logging.server.family)
       # Get and store the value of the port used, so the runners/tasks will be
       # able to connect
       if settings.logging.server.port == 0:
@@ -337,8 +338,12 @@ class BaseCompute:
                         "gracefully. Attempting to exit anyways.",
                         RuntimeWarning)
     elif settings.terra.zone == 'runner':
-      sender.main_log_handler = SocketHandler(
-          settings.logging.server.hostname, settings.logging.server.port)
+      if settings.logging.server.family == 'AF_UNIX':
+        sender.main_log_handler = SocketHandler(
+            settings.logging.server.listen_address, None)
+      else:
+        sender.main_log_handler = SocketHandler(
+            settings.logging.server.hostname, settings.logging.server.port)
       # All runners have access to the master controller's stderr by virtue of
       # running on the same host. By default, we go ahead and let them log
       # there. Consequently, there is no need for the master controller to echo

--- a/terra/compute/base.py
+++ b/terra/compute/base.py
@@ -8,6 +8,8 @@ from logging.handlers import SocketHandler
 import threading
 import warnings
 import shlex
+from pathlib import Path
+import socket
 
 from terra import settings
 import terra.compute.utils
@@ -300,6 +302,31 @@ class BaseCompute:
         sender._log_file = os.devnull
       if settings.processing_dir:
         os.makedirs(settings.processing_dir, exist_ok=True)
+
+      if settings.logging.server.family == "AF_UNIX":
+        # import pdb; pdb.set_trace()
+        socket_dir = Path(settings.logging.server.listen_address).parent
+        os.makedirs(socket_dir, exist_ok=True)
+        temp_filename = socket_dir / (
+            ".terra_test_" + settings.terra.uuid + ".sock")
+        temp_sock = socket.socket(socket.AF_UNIX, socket.SOCK_STREAM)
+        try:
+          temp_sock.bind(str(temp_filename))
+          temp_sock.close()
+        except OSError:
+          # /dev/shm should always work on Linux
+          settings.logging.server.listen_address = str(
+              Path("/dev/shm") / (
+                  ".terra_log_" + settings.terra.uuid + ".sock"))
+          logger.info(
+              f"{socket_dir} cannot handle file sockets. "
+              f"Using {settings.logging.server.listen_address} instead.")
+        finally:
+          try:
+            os.remove(temp_filename)
+          except Exception:
+            pass
+
       sender._log_file = open(sender._log_file, 'a')
       sender.main_log_handler = StreamHandler(stream=sender._log_file)
       sender.root_logger.addHandler(sender.main_log_handler)
@@ -367,7 +394,7 @@ class BaseCompute:
 
       # Check to see if _log_file is unset. If it is, this is due to _log_file
       # being called without configure being called. While it is not important
-      # this work, it's more likely for unit testsing
+      # this work, it's more likely for unit testing
       # if not os.path.samefile(log_file, sender._log_file.name):
       if getattr(sender, '_log_file', None) is not None and \
          log_file != sender._log_file.name:

--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -39,7 +39,7 @@ class ContainerService(BaseService):
 
     if settings.logging.server.family == 'AF_UNIX':
       self.add_file_readonly(settings.logging.server.listen_address,
-                             settings.logging.server.listen_address)
+                             "/terra_log.sock")
 
     self.temp_dir = TemporaryDirectory(suffix=f"_{type(self).__name__}")
     if self.env.get('TERRA_KEEP_TEMP_DIR', None) == "1":

--- a/terra/compute/container.py
+++ b/terra/compute/container.py
@@ -37,6 +37,10 @@ class ContainerService(BaseService):
     # for special executors, etc...
     super().pre_run()
 
+    if settings.logging.server.family == 'AF_UNIX':
+      self.add_file_readonly(settings.logging.server.listen_address,
+                             settings.logging.server.listen_address)
+
     self.temp_dir = TemporaryDirectory(suffix=f"_{type(self).__name__}")
     if self.env.get('TERRA_KEEP_TEMP_DIR', None) == "1":
       self.temp_dir._finalizer.detach()
@@ -177,7 +181,7 @@ class ContainerService(BaseService):
       remote = os.path.splitext(remote)[0] + local_ext
 
     # update volume
-    self.add_volume_readonly(local, remote, local_must_exist=True)
+    self.add_volume_readonly(local, remote)
 
   def add_file(self, local, remote, use_local_extension=False):
     '''

--- a/terra/core/settings.py
+++ b/terra/core/settings.py
@@ -389,7 +389,9 @@ def logging_listen_address(self):
     # since 2019: https://github.com/python/cpython/issues/77589
     return (self.logging.server.listen_host, self.logging.server.port)
   else:
-    return str(Path(self.processing_dir) / ".terra_log.sock")
+    return str(Path(self.processing_dir) / (
+        ".terra_log_" + self.terra.uuid + ".sock"))
+
 
 @settings_property
 def logging_family(self):

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -249,11 +249,13 @@ class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
       abort = self.abort
     self.ready = False
 
+
 def cleanup_named_socket(server_address):
   try:
     os.remove(server_address)
   except Exception:
     pass
+
 
 class _SetupTerraLogger():
   '''

--- a/terra/logger.py
+++ b/terra/logger.py
@@ -224,7 +224,7 @@ class LogRecordSocketReceiver(socketserver.ThreadingTCPServer):
       self.address_family = socket.AF_UNIX
     else:
       raise ValueError(f'Invalid value of socket family: {family}. Currently '
-                       'only AF_INET and AF_UNIX are supported')
+                       'only AF_INET, AF_INET6 and AF_UNIX are supported')
     socketserver.ThreadingTCPServer.__init__(self, address, handler)
 
     # Auto delete file socket, or else it'll cause a bind error next time, plus

--- a/terra/tests/test_compute_base.py
+++ b/terra/tests/test_compute_base.py
@@ -48,7 +48,8 @@ class TestServiceBase(TestSettingsConfigureCase):
       # only the contents of the service dir are overwritten
       foo_sub_dir = os.path.join(foo_dir, 'service_dir')
       os.makedirs(foo_sub_dir, exist_ok=True)
-      service.create_service_dir(foo_dir, overwrite)
+      with self.assertLogs("terra.compute.base", level='WARNING'):
+        service.create_service_dir(foo_dir, overwrite)
       # foo dir should now be empty
       dirs = os.listdir(foo_dir)
       self.assertEqual(len(dirs), 0)

--- a/terra/tests/test_compute_base.py
+++ b/terra/tests/test_compute_base.py
@@ -39,7 +39,7 @@ class TestServiceBase(TestSettingsConfigureCase):
       # a Runtime error should occur because the directory exists
       # and overwrite is false
       with self.assertRaises(RuntimeError):
-        with self.assertLogs("terra.compute.base", level='WARNING') as cm:
+        with self.assertLogs("terra.compute.base", level='WARNING'):
           service.create_service_dir(foo_dir, overwrite)
 
       # set overwrite to true

--- a/terra/tests/test_compute_base.py
+++ b/terra/tests/test_compute_base.py
@@ -39,7 +39,8 @@ class TestServiceBase(TestSettingsConfigureCase):
       # a Runtime error should occur because the directory exists
       # and overwrite is false
       with self.assertRaises(RuntimeError):
-        service.create_service_dir(foo_dir, overwrite)
+        with self.assertLogs("terra.compute.base", level='WARNING') as cm:
+          service.create_service_dir(foo_dir, overwrite)
 
       # set overwrite to true
       overwrite = True

--- a/terra/tests/test_compute_container.py
+++ b/terra/tests/test_compute_container.py
@@ -59,6 +59,9 @@ class TestContainerService(TestComputeContainerCase,
     self.config = config
 
   def common(self, compute, service):
+    with open(settings.logging.server.listen_address, 'w'):
+        pass
+
     service.pre_run()
     setup_dir = service.temp_dir.name
     config = self.config

--- a/terra/tests/test_compute_container.py
+++ b/terra/tests/test_compute_container.py
@@ -60,7 +60,7 @@ class TestContainerService(TestComputeContainerCase,
 
   def common(self, compute, service):
     with open(settings.logging.server.listen_address, 'w'):
-        pass
+      pass
 
     service.pre_run()
     setup_dir = service.temp_dir.name

--- a/terra/utils/path.py
+++ b/terra/utils/path.py
@@ -104,6 +104,11 @@ def translate_settings_paths(container_config, volume_map,
   if os.name == "nt":  # pragma: no linux cover
     logger.warning("Windows volume mapping is experimental.")
 
+  if container_config.logging.server.family == 'AF_UNIX':
+    container_config.logging.server.listen_address = patch_volume(
+        container_config.logging.server.listen_address,
+        reversed(volume_map))
+
   # Apply map translation to settings configuration
   return nested_patch(
       container_config,


### PR DESCRIPTION
Terra components (controller, runners, and task runners) use a BSD socket to communicate IPC using TCP.

This has been functioning using the standard IP network, but there have been issues with this over time:

1. Port in use. This has been fix by using port 0 to auto assign an port, but was historically a problem.
2. Firewall and IP routing can be a problem in some setups. Especially Windows using WSL. Sometimes it works when you use the right IP, and sometimes it doesn't.
3. Distributed computing needs a firewall to allow the communication.

With the file based socket, the first 2 issues are completely resolves. When running on a windows host, you will still need to use an IP socket, but that shouldn't be a problem, as there are not container networks to contend with.

The 3rd issue will still be the case. A file based socket does _not_ allow for different computers to communicate. That's not what it is. It's just a handle. In that case, using TCP/IP _is_ the correct method.