### PR TITLE
extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 from distutils.core import setup
 
-extra_requires = {
+extras_require = {
   'celery': ["celery[redis]"],
   'flower': ["flower"]
 }
@@ -8,7 +8,7 @@ extra_requires = {
 setup(name="terra",
       packages=["terra"],
       description="Terra",
-      extra_requires=extra_requires,
+      extras_require=extras_require,
       install_requires=[
         "pyyaml",
         "jstyleson",


### PR DESCRIPTION
Fix incorrect argument in `setup.py`, specifically `extra_requires` -> `extras_require`

https://setuptools.pypa.io/en/latest/userguide/dependency_management.html#optional-dependencies